### PR TITLE
Remove the partner's ping/mention

### DIFF
--- a/Classes/CE_Roll.py
+++ b/Classes/CE_Roll.py
@@ -520,7 +520,7 @@ class CERoll:
             )
         elif self.is_co_op() :
             return (
-                f"Sorry {user.mention()} and {partner.mention()}, you failed your {self.roll_name} roll. " +
+                f"Sorry {user.mention()} and {partner.display_name}, you failed your {self.roll_name} roll. " +
                 f"You are now on cooldown for {self.roll_name} until <t:{self.calculate_cooldown_date(database_name)}>."
             )
         elif self.roll_name == "One Hell of a Day" :


### PR DESCRIPTION
Since each user has a roll there will need to be 2x messages sent in the discord server.

I think what I've changed should remove the partner ping, and show the display name instead in the message.

The partner will still get a ping in their message