### PR TITLE
Re-attempt the API call if it fails during a loop

### DIFF
--- a/Modules/CEAPIReader.py
+++ b/Modules/CEAPIReader.py
@@ -127,9 +127,11 @@ async def get_api_games_full() -> list[CEAPIGame] :
             
             #for each iteration (PULL_LIMIT), allow the site to be queried a few times in case of failure
             for x in range(TRY_LIMIT):
-                
-                str_error = None #resets for each call to the full games api
-                
+
+                # set up a variable used to catch errors
+                str_error = None
+
+                # try to call the API
                 try:
                     async with session.get(f"https://cedb.me/api/games/full?limit={PULL_LIMIT}&offset={(i-1)*PULL_LIMIT}") as response :
                         j = await response.json()
@@ -137,22 +139,23 @@ async def get_api_games_full() -> list[CEAPIGame] :
                         done_fetching = len(j) == 0
                         i += 1
               
-                # if an error, set "str_error" to a value, which will enable the error catch/retry below
+                # if we got an error from the API call, set "str_error" to a value to enable the error catch/retry below
                 except Exception as e:
                     str_error = e
                     pass
+                
                 
                 # if an error, print a message and try again until TRY_LIMIT attempts completed for this batch of PULL_LIMIT games
                 if str_error:
                     print(f"Scraping failed from api/games/full on games {(i-1)*PULL_LIMIT} through {i*PULL_LIMIT-1}." + " Attempt " + str(x+1) + " of " + str(TRY_LIMIT))
             
-                    # if it's failed 'y' times, give up on the detailed scrape
+                    # if this block of games have failed TRY_LIMIT times, throw an exception and go to sleep
                     if x+1 == TRY_LIMIT:
                         raise FailedScrapeException(f"Scraping failed from api/games/full " 
                                             + f"on games {(i-1)*PULL_LIMIT} through {i*PULL_LIMIT-1}.")
 
+                # if no error - continue on to the next block of "PULL LIMIT" games
                 else:
-                    # if no error - continue on to the next block of "PULL LIMIT" games
                     break
             
     print(f"done fetching games! total games: {len(json_response)}")

--- a/Modules/CEAPIReader.py
+++ b/Modules/CEAPIReader.py
@@ -112,25 +112,49 @@ def _ce_to_game(json_response : dict) -> CEAPIGame :
 async def get_api_games_full() -> list[CEAPIGame] :
     """Returns an array of :class:`CEAPIGame`'s grabbed from https://cedb.me/api/games/full"""
     # Step 1: get the big json intact.
-    PULL_LIMIT = 50
+    PULL_LIMIT = 50 #grab this many games per API call
+    TRY_LIMIT = 3 # try each batch of 'PULL LIMIT' this many times
     json_response = []
     done_fetching : bool = False
     i = 1
-    async with aiohttp.ClientSession() as session :
-        
-        try:
-            while (not done_fetching) :
-                print(f"fetching games {(i-1)*PULL_LIMIT} through {i*PULL_LIMIT-1}...")
-                async with session.get(f"https://cedb.me/api/games/full?limit={PULL_LIMIT}&" 
-                                                + f"offset={(i-1)*PULL_LIMIT}") as response :
-                    j = await response.json()
-                    json_response += j
-                    done_fetching = len(j) == 0
-                    i += 1
-        except : 
-            raise FailedScrapeException(f"Scraping failed from api/games/full " 
-                                        + f"on games {(i-1)*PULL_LIMIT} through {i*PULL_LIMIT-1}.")
     
+    async with aiohttp.ClientSession() as session :
+
+        #overarching while statement - if not done, keep going
+        while (not done_fetching):
+            
+            print(f"fetching games {(i-1)*PULL_LIMIT} through {i*PULL_LIMIT-1}...")
+            
+            #for each iteration (PULL_LIMIT), allow the site to be queried a few times in case of failure
+            for x in range(TRY_LIMIT):
+                
+                str_error = None #resets for each call to the full games api
+                
+                try:
+                    async with session.get(f"https://cedb.me/api/games/full?limit={PULL_LIMIT}&offset={(i-1)*PULL_LIMIT}") as response :
+                        j = await response.json()
+                        json_response += j
+                        done_fetching = len(j) == 0
+                        i += 1
+              
+                # if an error, set "str_error" to a value, which will enable the error catch/retry below
+                except Exception as e:
+                    str_error = e
+                    pass
+                
+                # if an error, print a message and try again until TRY_LIMIT attempts completed for this batch of PULL_LIMIT games
+                if str_error:
+                    print(f"Scraping failed from api/games/full on games {(i-1)*PULL_LIMIT} through {i*PULL_LIMIT-1}." + " Attempt " + str(x+1) + " of " + str(TRY_LIMIT))
+            
+                    # if it's failed 'y' times, give up on the detailed scrape
+                    if x+1 == TRY_LIMIT:
+                        raise FailedScrapeException(f"Scraping failed from api/games/full " 
+                                            + f"on games {(i-1)*PULL_LIMIT} through {i*PULL_LIMIT-1}.")
+
+                else:
+                    # if no error - continue on to the next block of "PULL LIMIT" games
+                    break
+            
     print(f"done fetching games! total games: {len(json_response)}")
 
     """"


### PR DESCRIPTION
Aimed to keep the same code function under the hood, but adjusted the structure to enable some error catching.
If we fail to get info from the api call, rather than go straight to "Scraping failed from api/games/full" and ending the update, give each block a couple of extra attempts.

May want to check that the "if x+1 == TRY_LIMIT:" segment behaves as expected - I'm hoping using your exception should end the update in the same way you've had it in the past, but I've only tested the block of code in isolation locally.