### PR TITLE
Bugfix: "Your roll is due at <t:None>"

### DIFF
--- a/Classes/CE_Roll.py
+++ b/Classes/CE_Roll.py
@@ -802,23 +802,43 @@ class CERoll:
     def get_fail_message(
         self, database_name: list[CEGame], user: CEUser, partner: CEUser | None
     ) -> str:
-        """Returns a string to send to #casino if this roll is failed."""
-        # TODO: finish this function
+        """
+        Returns a string to send to #casino if this roll is failed.
 
-        # and grab the objects
-        if not self.is_co_op:
-            partner = None
+        Parameters
+        ---
+        database_name: `list[CEGame]`
+            A list of CEGame objects that will need to be
+            referenced in this message.
+        user: `CEUser`
+            The user who rolled this event.
+        partner: `CEUser | None`
+            If this is a multi-player event, the user information
+            for the partner.
 
+        Returns
+        ---
+        message: `str`
+            The message to be sent to #casino. Examples:
+            - Sorry <@12345>, you have failed your Tier 1 in Fourward Thinking. You are now on cooldown
+              for Fourward Thinking until <t:12345>.
+            - Sorry <@12345> and <@67890>, you have failed your Soul Mates roll. You are now on cooldown for
+              Soul Mates until <t:12345>.
+            - Sorry <@12345>, you have failed your One Hell of a Day roll (Froggy's Battle). You are now on cooldown
+              until <t:12345>
+            - Sorry <@12345>, you have failed your Two Week T2 Streak roll. This event has no cooldown!
+
+        """
         if self.roll_name == "Fourward Thinking":
             return (
-                f"Sorry <@{user.discord_id}>, you failed your Tier {len(self.games)} in Fourward Thinking. "
+                f"Sorry {user.mention()}, you failed your Tier {len(self.games)} in Fourward Thinking. "
                 + f"You are now on cooldown for Fourward Thinking until <t:{self.calculate_cooldown_timestamp()}>."
             )
         elif self.is_co_op:
             if partner is None:
                 return "Error code 5. Contact andy."
             return (
-                f"Sorry {user.mention()} and {partner.display_name}, you failed your {self.roll_name} roll. "
+                f"Sorry {user.mention()} and {partner.mention()}, you failed your {self.roll_name} roll. "
                 + f"You are now on cooldown for {self.roll_name} until <t:{self.calculate_cooldown_timestamp()}>."
             )
         elif self.roll_name == "One Hell of a Day":
@@ -829,8 +849,13 @@ class CERoll:
                 )
                 raise Exception("Could not find game with ID in database_name.")
             return (
-                f"Sorry <@{user.discord_id}>, you failed your {self.roll_name} roll ({game.game_name}). "
+                f"Sorry {user.mention()}, you failed your {self.roll_name} roll ({game.game_name}). "
                 + f"You are now on cooldown for {self.roll_name} until <t:{self.calculate_cooldown_timestamp()}>."
+            )
+        elif self.calculate_cooldown_date() is None:
+            return (
+                f"Sorry {user.mention()}, you failed your {self.roll_name} roll. "
+                "This event has no cooldown!"
             )
         else:
             return (

--- a/commands/casino.py
+++ b/commands/casino.py
@@ -289,18 +289,26 @@ async def solo_roll(
                 )
             game_strings.append(_game_object.name_with_link)
 
+        # write the message
         message = (
             f"In your {event_name} roll, "
             f"you rolled the following games: {hm.get_grammar_str(game_strings)}. "
-            f"You have until {roll.due_discord_timestamp} to complete this event!"
         )
 
-        if len(message) > 2000:
+        # message was too long
+        if len(message) > 1900:
             message = (
-                f"In your {event_name} roll, "
-                f"the games you rolled did not fit in one message. Please run /check-rolls to see the full list. "
+                f"In your {event_name} roll, the games you rolled did not "
+                "fit in one message. Please run /check-rolls to see the full list. "
+            )
+
+        # tack on at the end
+        if roll.ends:
+            message += (
                 f"You have until {roll.due_discord_timestamp} to complete this event!"
             )
+        else:
+            message += "This event has no time limit. To fail and restart this event, run /solo-roll again!"
 
     SupabaseReader.dump_roll(roll)
     return await interaction.followup.send(message)

--- a/tests/unit/test_scraper_update_one_roll.py
+++ b/tests/unit/test_scraper_update_one_roll.py
@@ -1,0 +1,238 @@
+import datetime
+
+import pytest
+
+from Classes.CE_User import MUTELIST_CEIDS
+from web_scraper.scraper import UpdateMessageForScraperProcess, update_one_roll
+from Classes.CE_Roll import CERoll
+from tests.conftest import make_game, make_roll, make_user
+
+GAME_ID = "game-001-0000-0000-000000000000"
+ROLL_NAME = "One Hell of a Day"
+MUTED_CE_ID = MUTELIST_CEIDS[0]
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _past(minutes: int = 10) -> datetime.datetime:
+    return _now() - datetime.timedelta(minutes=minutes)
+
+
+def _future(minutes: int = 10) -> datetime.datetime:
+    return _now() + datetime.timedelta(minutes=minutes)
+
+
+def _pending(due_time: datetime.datetime | None = None):
+    return make_roll(
+        roll_name=ROLL_NAME,
+        status="pending",
+        due_time=due_time if due_time is not None else _future(),
+        games=[GAME_ID],
+    )
+
+
+def _roll(status: str):
+    return make_roll(roll_name=ROLL_NAME, status=status, games=[GAME_ID])
+
+
+def _user():
+    return make_user()
+
+
+def _muted_user():
+    return make_user(ce_id=MUTED_CE_ID)
+
+
+def _games():
+    return [make_game(ce_id=GAME_ID)]
+
+
+# ── Return shape ──────────────────────────────────────────────────────────────
+
+
+class TestUpdateOneRollReturnShape:
+    def test_returns_tuple(self):
+        result = update_one_roll(_pending(), _user(), None, _games())
+        assert isinstance(result, tuple)
+
+    def test_returns_three_elements(self):
+        result = update_one_roll(_pending(), _user(), None, _games())
+        assert len(result) == 3
+
+    def test_first_element_is_update_or_none(self):
+        update, _, __ = update_one_roll(_pending(), _user(), None, _games())
+        assert update is None or isinstance(update, UpdateMessageForScraperProcess)
+
+    def test_second_element_is_roll_or_none(self):
+        _, roll_updated, __ = update_one_roll(_pending(), _user(), None, _games())
+        assert roll_updated is None or isinstance(roll_updated, CERoll)
+
+    def test_third_element_is_bool(self):
+        _, __, delete_pending = update_one_roll(_pending(), _user(), None, _games())
+        assert isinstance(delete_pending, bool)
+
+    def test_shape_is_consistent_for_current_roll(self):
+        result = update_one_roll(_roll("current"), _user(), None, _games())
+        assert isinstance(result, tuple) and len(result) == 3
+
+
+# ── delete_pending — pending rolls ────────────────────────────────────────────
+
+
+class TestDeletePendingForPendingRolls:
+    def test_unexpired_pending_is_false(self):
+        _, __, delete_pending = update_one_roll(
+            _pending(_future()), _user(), None, _games()
+        )
+        assert delete_pending is False
+
+    def test_expired_pending_is_true(self):
+        _, __, delete_pending = update_one_roll(
+            _pending(_past()), _user(), None, _games()
+        )
+        assert delete_pending is True
+
+    def test_just_expired_one_second_ago_is_true(self):
+        just_expired = _now() - datetime.timedelta(seconds=1)
+        _, __, delete_pending = update_one_roll(
+            _pending(just_expired), _user(), None, _games()
+        )
+        assert delete_pending is True
+
+    def test_expiring_far_future_is_false(self):
+        far_future = _now() + datetime.timedelta(days=365)
+        _, __, delete_pending = update_one_roll(
+            _pending(far_future), _user(), None, _games()
+        )
+        assert delete_pending is False
+
+    def test_expired_long_ago_is_true(self):
+        long_past = _now() - datetime.timedelta(hours=24)
+        _, __, delete_pending = update_one_roll(
+            _pending(long_past), _user(), None, _games()
+        )
+        assert delete_pending is True
+
+    def test_pending_no_due_time_is_false(self):
+        # No due_time means it never expires
+        roll = make_roll(
+            roll_name="Never Lucky", status="pending", due_time=None, games=[GAME_ID]
+        )
+        _, __, delete_pending = update_one_roll(roll, _user(), None, _games())
+        assert delete_pending is False
+
+
+# ── delete_pending — non-pending statuses always False ────────────────────────
+
+
+class TestDeletePendingAlwaysFalseForNonPending:
+    @pytest.mark.parametrize(
+        "status",
+        ["current", "won", "failed", "between_stages", "removed", "won_legacy"],
+    )
+    def test_non_pending_status_never_sets_delete_pending(self, status):
+        _, __, delete_pending = update_one_roll(_roll(status), _user(), None, _games())
+        assert delete_pending is False
+
+
+# ── roll_updated semantics for pending rolls ──────────────────────────────────
+
+
+class TestRollUpdatedForPendingRolls:
+    def test_unexpired_pending_has_no_roll_updated(self):
+        _, roll_updated, __ = update_one_roll(
+            _pending(_future()), _user(), None, _games()
+        )
+        assert roll_updated is None
+
+    def test_expired_pending_has_no_roll_updated(self):
+        # Expired pending is deleted, not modified — roll_updated should be None
+        _, roll_updated, __ = update_one_roll(
+            _pending(_past()), _user(), None, _games()
+        )
+        assert roll_updated is None
+
+
+# ── Pending rolls with a partner (user2) ─────────────────────────────────────
+
+
+class TestPendingRollWithUser2:
+    def test_unexpired_pending_with_partner_delete_pending_false(self):
+        user2 = make_user(ce_id="user-002-0000-0000-000000000000")
+        _, __, delete_pending = update_one_roll(
+            _pending(_future()), _user(), user2, _games()
+        )
+        assert delete_pending is False
+
+    def test_expired_pending_with_partner_delete_pending_true(self):
+        user2 = make_user(ce_id="user-002-0000-0000-000000000000")
+        _, __, delete_pending = update_one_roll(
+            _pending(_past()), _user(), user2, _games()
+        )
+        assert delete_pending is True
+
+    def test_pending_with_partner_returns_three_tuple(self):
+        user2 = make_user(ce_id="user-002-0000-0000-000000000000")
+        result = update_one_roll(_pending(_future()), _user(), user2, _games())
+        assert isinstance(result, tuple) and len(result) == 3
+
+
+# ── user2=None is valid for solo rolls ───────────────────────────────────────
+
+
+class TestSoloRollUser2None:
+    def test_current_roll_solo_does_not_crash(self):
+        result = update_one_roll(_roll("current"), _user(), None, _games())
+        assert isinstance(result, tuple)
+
+    def test_pending_roll_solo_does_not_crash(self):
+        result = update_one_roll(_pending(_future()), _user(), None, _games())
+        assert isinstance(result, tuple)
+
+
+# ── Muted user1 ───────────────────────────────────────────────────────────────
+
+
+class TestMutedUser:
+    def test_muted_user_pending_expired_still_sets_delete_pending_true(self):
+        _, __, delete_pending = update_one_roll(
+            _pending(_past()), _muted_user(), None, _games()
+        )
+        assert delete_pending is True
+
+    def test_muted_user_pending_unexpired_still_false(self):
+        _, __, delete_pending = update_one_roll(
+            _pending(_future()), _muted_user(), None, _games()
+        )
+        assert delete_pending is False
+
+    def test_muted_user_update_if_present_goes_to_privatelog(self):
+        update, _, __ = update_one_roll(_roll("current"), _muted_user(), None, _games())
+        if update is not None:
+            assert update.location == "privatelog"
+
+    def test_non_muted_user_update_if_present_does_not_go_to_privatelog(self):
+        update, _, __ = update_one_roll(_roll("current"), _user(), None, _games())
+        if update is not None:
+            assert update.location != "privatelog"
+
+
+# ── Update message — basic guarantees ────────────────────────────────────────
+
+
+class TestUpdateMessageGuarantees:
+    def test_unexpired_pending_produces_no_update(self):
+        update, _, __ = update_one_roll(_pending(_future()), _user(), None, _games())
+        assert update is None
+
+    def test_if_update_present_location_is_set(self):
+        update, _, __ = update_one_roll(_roll("current"), _user(), None, _games())
+        if update is not None:
+            assert update.location is not None
+
+    def test_if_update_present_is_embed_is_bool(self):
+        update, _, __ = update_one_roll(_roll("current"), _user(), None, _games())
+        if update is not None:
+            assert isinstance(update.is_embed, bool)

--- a/tests/unit/test_scraper_update_one_roll.py
+++ b/tests/unit/test_scraper_update_one_roll.py
@@ -37,6 +37,12 @@ def _roll(status: str):
     return make_roll(roll_name=ROLL_NAME, status=status, games=[GAME_ID])
 
 
+def _expired_current():
+    return make_roll(
+        roll_name=ROLL_NAME, status="current", due_time=_past(), games=[GAME_ID]
+    )
+
+
 def _user():
     return make_user()
 
@@ -208,15 +214,19 @@ class TestMutedUser:
         )
         assert delete_pending is False
 
-    def test_muted_user_update_if_present_goes_to_privatelog(self):
-        update, _, __ = update_one_roll(_roll("current"), _muted_user(), None, _games())
-        if update is not None:
-            assert update.location == "privatelog"
+    def test_muted_user_expired_roll_goes_to_casino_not_privatelog(self):
+        # update_one_roll routes casino messages to "casino"/"casinolog", never "privatelog"
+        # (privatelog routing is for scraper notifications like check_rank, not roll outcomes)
+        update, _, __ = update_one_roll(
+            _expired_current(), _muted_user(), None, _games()
+        )
+        assert update is not None
+        assert update.location != "privatelog"
 
-    def test_non_muted_user_update_if_present_does_not_go_to_privatelog(self):
-        update, _, __ = update_one_roll(_roll("current"), _user(), None, _games())
-        if update is not None:
-            assert update.location != "privatelog"
+    def test_non_muted_user_expired_roll_goes_to_casino_not_privatelog(self):
+        update, _, __ = update_one_roll(_expired_current(), _user(), None, _games())
+        assert update is not None
+        assert update.location != "privatelog"
 
 
 # ── Update message — basic guarantees ────────────────────────────────────────
@@ -227,12 +237,12 @@ class TestUpdateMessageGuarantees:
         update, _, __ = update_one_roll(_pending(_future()), _user(), None, _games())
         assert update is None
 
-    def test_if_update_present_location_is_set(self):
-        update, _, __ = update_one_roll(_roll("current"), _user(), None, _games())
-        if update is not None:
-            assert update.location is not None
+    def test_expired_roll_update_has_location_set(self):
+        update, _, __ = update_one_roll(_expired_current(), _user(), None, _games())
+        assert update is not None
+        assert update.location is not None
 
-    def test_if_update_present_is_embed_is_bool(self):
-        update, _, __ = update_one_roll(_roll("current"), _user(), None, _games())
-        if update is not None:
-            assert isinstance(update.is_embed, bool)
+    def test_expired_roll_update_is_embed_is_bool(self):
+        update, _, __ = update_one_roll(_expired_current(), _user(), None, _games())
+        assert update is not None
+        assert isinstance(update.is_embed, bool)


### PR DESCRIPTION
Changes the text from:
> "In your Never Lucky roll, you rolled the following games: [Paint the Town Red](https://cedb.me/game/841a87d2-da4f-436b-ada8-1d4ba520ef97). You have until <t:None> to complete this event!"

to
> "In your Never Lucky roll, you rolled the following games: [Paint the Town Red](https://cedb.me/game/841a87d2-da4f-436b-ada8-1d4ba520ef97). This event has no time limit. To fail and restart this event, run /solo-roll again!"