### PR TITLE
Bugfix: No "pending" rolls saved on a cancellation call

### DIFF
--- a/Classes/CE_User.py
+++ b/Classes/CE_User.py
@@ -407,6 +407,12 @@ class CEUser:
                 break
         pass
 
+    def get_pending(self, pending: hm.ALL_ROLL_EVENT_NAMES) -> CERoll | None:
+        for p in self.rolls:
+            if p.roll_name == pending and p.status == "pending":
+                return p
+        return None
+
     def has_pending(self, roll_name: hm.ALL_ROLL_EVENT_NAMES) -> bool:
         """Returns true if this user is currently on pending for `roll_name`."""
         for pending in self.pending_rolls:

--- a/commands/casino.py
+++ b/commands/casino.py
@@ -123,6 +123,16 @@ async def solo_roll(
                 )
 
             # if we get here, we can cancel
+            # MAKE SURE WE ADD THE PENDING SO THEY CAN'T DOUBLE DO THIS!!!
+            user.add_pending(event_name)
+            _pending: CERoll | None = user.get_pending(event_name)
+            if _pending is None:
+                return await interaction.followup.send(
+                    "Ran into an error with the pending system."
+                )
+            SupabaseReader.dump_roll(_pending)
+
+            # and now send the views
             view = ConfirmCancelView(user.discord_id)
             await interaction.followup.send(
                 f"You have an active **{event_name}** roll. Rerolling will **fail** it permanently. Continue?",
@@ -130,7 +140,10 @@ async def solo_roll(
             )
             await view.wait()
 
-            # they said no
+            # they said no (or yes) — tear down the pending guard
+            _pending_id = _pending._id
+            user.remove_pending(event_name)
+            SupabaseReader.delete_roll(_pending_id)
             if not view.confirmed:
                 return await interaction.edit_original_response(
                     content="Reroll cancelled.", view=None


### PR DESCRIPTION
If a user wanted to reroll Never Lucky, they would be able to do it twice. This will prevent that.