### PR TITLE
/fail-roll command

### DIFF
--- a/Modules/SupabaseReader.py
+++ b/Modules/SupabaseReader.py
@@ -998,7 +998,7 @@ def dump_roll(roll: CERoll):
         "time_created": _iso_or_none(roll.init_time),
         "time_due": _iso_or_none(roll.due_time),
         "time_completed": _iso_or_none(roll.completed_time),
-        "is_lucky": roll.lucky,  # TODO: determine from roll data
+        "is_lucky": roll.lucky,
         "chosen_tier": roll._tier_num,
         "chosen_tier_partner": roll._tier_num_partner,
         "status": roll.status,

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -111,8 +111,16 @@ def setup(cli: discord.Client, tree: app_commands.CommandTree, gui: discord.Guil
         description="Given a roll ID, change the status from 'current' to 'failed'.",
         guild=guild,
     )
-    async def fail_roll_command(interaction: discord.Interaction, roll_id: str):
-        return await interaction.response.send_message("In progress!")
+    @app_commands.describe(
+        roll_id="The ID of the roll you're updating. See https://cebot.me to find it."
+    )
+    @app_commands.describe(
+        is_not_current="Set this to true if you'd like to ignore the current status."
+    )
+    async def fail_roll_command(
+        interaction: discord.Interaction, roll_id: str, is_not_current: bool = False
+    ):
+        return await fail_roll(interaction, roll_id, is_not_current)
 
     # ---- force add command ----
     @tree.command(
@@ -308,9 +316,7 @@ async def add_notes(
     # update existing Note field if present, otherwise add one
     if embed.fields and embed.fields[-1].name == "Note":
         if clear:
-            embed.set_field_at(
-                index=len(embed.fields) - 1, name="Note", value=notes
-            )
+            embed.set_field_at(index=len(embed.fields) - 1, name="Note", value=notes)
         else:
             old_notes = embed.fields[-1].value
             embed.set_field_at(
@@ -409,6 +415,77 @@ async def clear_roll_portion(
     return await interaction.followup.send(
         f"Removed {game_removed} from {user.display_name}'s {roll_name} roll. "
         + "Status set to 'waiting'."
+    )
+
+
+async def fail_roll(
+    interaction: discord.Interaction, roll_id: str, is_not_current: bool = False
+):
+    """
+    Takes in an `interaction: discord.Interaction` and a `roll_id: str`
+    and changes the status from 'current' to 'failed'.
+
+    If the status is not 'current', this will exit,
+    unless the `is_not_current: bool` is set to `True`.
+
+    Parameters
+    ---
+    interaction: `discord.Interaction`
+        The interaction we're responding to.
+    roll_id: `str`
+        The ID of the roll we're changing the
+        status of.
+    is_not_current: `bool = False`
+        Optional boolean flag. When set to true,
+        we force the status to be set to 'failed'
+        regardless of what the current status is.
+    """
+
+    await interaction.response.defer(ephemeral=True)
+
+    await hm.log_command(
+        client,
+        interaction,
+        "fail_roll",
+        True,
+        roll_id=roll_id,
+        is_not_current=is_not_current,
+    )
+
+    roll = SupabaseReader.get_roll(roll_id)
+    if roll is None:
+        return await interaction.followup.send(f"No roll with ID {roll_id} was found.")
+
+    if roll.status != "current" and not is_not_current:
+        return await interaction.followup.send(
+            f"The status of this roll is {roll.status}. This command (by default) only fails rolls that have "
+            "a status of 'current'. If you would still like to set the status of this roll to 'failed', please "
+            "rerun this command with the parameter `is_not_current` set to true."
+        )
+
+    roll.set_status("failed")
+    SupabaseReader.dump_roll(roll)
+
+    await interaction.followup.send(
+        f"Roll with ID {roll_id}'s status has now been set to 'failed'."
+    )
+
+    # report failure to #casino
+    database_name = SupabaseReader.get_database_name()
+    user = SupabaseReader.get_user(roll.user_ce_id)
+    if user is None:
+        return await hm.send_message(
+            client, "casino", f"Roll with ID {roll.id} failed. User not found."
+        )
+    if roll.partner_ce_id is None:
+        partner = None
+    else:
+        partner = SupabaseReader.get_user(roll.partner_ce_id)
+    return await hm.send_message(
+        client,
+        "casino",
+        roll.get_fail_message(database_name, user, partner),
+        allowed_mentions=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,11 @@ Each factory exposes only the parameters that individual tests care about;
 everything else gets a safe default.
 """
 
+# Prevent SupabaseReader from making network calls at import time.
+# This must run before any test module imports SupabaseReader (directly or transitively).
+from unittest.mock import patch as _patch
+_patch("Modules.LocalCache.rebuild_from_supabase", return_value=None).start()
+
 import datetime
 from typing import cast
 import uuid

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,9 @@ Each factory exposes only the parameters that individual tests care about;
 everything else gets a safe default.
 """
 
-# Prevent SupabaseReader from making network calls at import time.
-# This must run before any test module imports SupabaseReader (directly or transitively).
-from unittest.mock import patch as _patch
-_patch("Modules.LocalCache.rebuild_from_supabase", return_value=None).start()
-
 import datetime
 from typing import cast
+from unittest.mock import patch as _patch
 import uuid
 
 from Classes.CE_Objective import CEObjective
@@ -20,6 +16,10 @@ from Classes.CE_User import CEUser
 from Classes.CE_User_Game import CEUserGame
 from Classes.CE_User_Objective import CEUserObjective
 from Modules import hm
+
+# Prevent SupabaseReader from making network calls at import time.
+# Must run before any test module imports SupabaseReader (directly or transitively).
+_patch("Modules.LocalCache.rebuild_from_supabase", return_value=None).start()
 
 
 def make_objective(

--- a/tests/unit/test_admin_commands.py
+++ b/tests/unit/test_admin_commands.py
@@ -187,7 +187,7 @@ class TestFailRoll:
             import commands.admin as admin_mod
 
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
-                asyncio.run(fail_roll(interaction, "bad-id", False))
+                asyncio.run(fail_roll(interaction, "bad-id", False))  # type: ignore[arg-type]
         mock_dump.assert_not_called()
 
     # ── non-current roll, flag not set ────────────────────────────────────────
@@ -220,7 +220,7 @@ class TestFailRoll:
             import commands.admin as admin_mod
 
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
-                asyncio.run(fail_roll(interaction, "roll-001", False))
+                asyncio.run(fail_roll(interaction, "roll-001", False))  # type: ignore[arg-type]
         mock_dump.assert_not_called()
 
     # ── current roll succeeds ─────────────────────────────────────────────────
@@ -245,7 +245,7 @@ class TestFailRoll:
             import commands.admin as admin_mod
 
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
-                asyncio.run(fail_roll(interaction, "roll-001", False))
+                asyncio.run(fail_roll(interaction, "roll-001", False))  # type: ignore[arg-type]
         mock_dump.assert_called_once_with(roll)
 
     def test_current_roll_sends_success_message(self):
@@ -296,7 +296,7 @@ class TestFailRoll:
             import commands.admin as admin_mod
 
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
-                asyncio.run(fail_roll(interaction, "roll-001", False))
+                asyncio.run(fail_roll(interaction, "roll-001", False))  # type: ignore[arg-type]
         mock_get_user.assert_called_once_with(roll.user_ce_id)
 
     def test_co_op_roll_looks_up_both_users(self):
@@ -315,7 +315,7 @@ class TestFailRoll:
             import commands.admin as admin_mod
 
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
-                asyncio.run(fail_roll(interaction, "roll-001", False))
+                asyncio.run(fail_roll(interaction, "roll-001", False))  # type: ignore[arg-type]
         called_ids = {c[0][0] for c in mock_get_user.call_args_list}
         assert roll.user_ce_id in called_ids
         assert "partner-001" in called_ids
@@ -336,7 +336,7 @@ class TestFailRoll:
             import commands.admin as admin_mod
 
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
-                asyncio.run(fail_roll(interaction, "roll-001", False))
+                asyncio.run(fail_roll(interaction, "roll-001", False))  # type: ignore[arg-type]
         _, channel, msg = mock_send.call_args[0]
         assert channel == "casino"
         assert "not found" in msg.lower()

--- a/tests/unit/test_admin_commands.py
+++ b/tests/unit/test_admin_commands.py
@@ -1,6 +1,6 @@
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from commands.admin import fail_roll, loop
 

--- a/tests/unit/test_admin_commands.py
+++ b/tests/unit/test_admin_commands.py
@@ -1,8 +1,8 @@
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
-from commands.admin import loop
+from commands.admin import fail_roll, loop
 
 
 class TestAdminLoopCommand:
@@ -115,3 +115,210 @@ class TestAdminLoopCommand:
             self._run(interaction, full_scrape=True)
 
         assert interaction.followup.send.await_count == 1
+
+
+# ── fail_roll ─────────────────────────────────────────────────────────────────
+
+
+class TestFailRoll:
+    def _make_interaction(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            response=SimpleNamespace(defer=AsyncMock()),
+            followup=SimpleNamespace(send=AsyncMock()),
+        )
+
+    def _make_roll(self, status: str = "current", partner_ce_id: str | None = None):
+        roll = MagicMock()
+        roll.status = status
+        roll.user_ce_id = "user-001-0000-0000-000000000000"
+        roll.partner_ce_id = partner_ce_id
+        roll.get_fail_message = MagicMock(return_value="the fail message")
+        return roll
+
+    def _run(
+        self,
+        interaction,
+        roll_id: str = "roll-001",
+        is_not_current: bool = False,
+        get_roll_return=None,
+        get_user_side_effect=None,
+    ):
+        import commands.admin as admin_mod
+
+        mock_user = MagicMock()
+        get_user_return = get_user_side_effect or (lambda _: mock_user)
+
+        with (
+            patch.object(admin_mod, "client", create=True, new=MagicMock()),
+            patch("commands.admin.hm.log_command", new_callable=AsyncMock),
+            patch("commands.admin.hm.send_message", new_callable=AsyncMock) as mock_send,
+            patch("commands.admin.SupabaseReader.get_roll", return_value=get_roll_return),
+            patch("commands.admin.SupabaseReader.dump_roll"),
+            patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
+            patch("commands.admin.SupabaseReader.get_user", side_effect=get_user_return),
+        ):
+            asyncio.run(fail_roll(interaction, roll_id, is_not_current))
+            return mock_send
+
+    # ── roll not found ────────────────────────────────────────────────────────
+
+    def test_roll_not_found_sends_error(self):
+        interaction = self._make_interaction()
+        self._run(interaction, roll_id="bad-id", get_roll_return=None)
+        msg = interaction.followup.send.call_args[0][0]
+        assert "bad-id" in msg
+
+    def test_roll_not_found_does_not_persist(self):
+        interaction = self._make_interaction()
+        with (
+            patch("commands.admin.SupabaseReader.get_roll", return_value=None),
+            patch("commands.admin.SupabaseReader.dump_roll") as mock_dump,
+            patch("commands.admin.hm.log_command", new_callable=AsyncMock),
+            patch("commands.admin.hm.send_message", new_callable=AsyncMock),
+            patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
+            patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()),
+        ):
+            import commands.admin as admin_mod
+            with patch.object(admin_mod, "client", create=True, new=MagicMock()):
+                asyncio.run(fail_roll(interaction, "bad-id", False))
+        mock_dump.assert_not_called()
+
+    # ── non-current roll, flag not set ────────────────────────────────────────
+
+    def test_non_current_roll_blocked_without_flag(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="won")
+        self._run(interaction, get_roll_return=roll, is_not_current=False)
+        msg = interaction.followup.send.call_args[0][0]
+        assert "won" in msg
+
+    def test_non_current_roll_blocked_hints_at_flag(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="removed")
+        self._run(interaction, get_roll_return=roll, is_not_current=False)
+        msg = interaction.followup.send.call_args[0][0]
+        assert "is_not_current" in msg
+
+    def test_non_current_roll_blocked_does_not_persist(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="won")
+        with (
+            patch("commands.admin.SupabaseReader.get_roll", return_value=roll),
+            patch("commands.admin.SupabaseReader.dump_roll") as mock_dump,
+            patch("commands.admin.hm.log_command", new_callable=AsyncMock),
+            patch("commands.admin.hm.send_message", new_callable=AsyncMock),
+            patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
+            patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()),
+        ):
+            import commands.admin as admin_mod
+            with patch.object(admin_mod, "client", create=True, new=MagicMock()):
+                asyncio.run(fail_roll(interaction, "roll-001", False))
+        mock_dump.assert_not_called()
+
+    # ── current roll succeeds ─────────────────────────────────────────────────
+
+    def test_current_roll_sets_status_to_failed(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="current")
+        self._run(interaction, get_roll_return=roll)
+        roll.set_status.assert_called_once_with("failed")
+
+    def test_current_roll_persists(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="current")
+        with (
+            patch("commands.admin.SupabaseReader.get_roll", return_value=roll),
+            patch("commands.admin.SupabaseReader.dump_roll") as mock_dump,
+            patch("commands.admin.hm.log_command", new_callable=AsyncMock),
+            patch("commands.admin.hm.send_message", new_callable=AsyncMock),
+            patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
+            patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()),
+        ):
+            import commands.admin as admin_mod
+            with patch.object(admin_mod, "client", create=True, new=MagicMock()):
+                asyncio.run(fail_roll(interaction, "roll-001", False))
+        mock_dump.assert_called_once_with(roll)
+
+    def test_current_roll_sends_success_message(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="current")
+        self._run(interaction, get_roll_return=roll)
+        # first followup is the success message to the admin
+        msg = interaction.followup.send.call_args_list[0][0][0]
+        assert "failed" in msg.lower()
+
+    def test_current_roll_posts_to_casino_channel(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="current")
+        mock_send = self._run(interaction, get_roll_return=roll)
+        mock_send.assert_awaited_once()
+        _, channel, _ = mock_send.call_args[0]
+        assert channel == "casino"
+
+    # ── is_not_current override ───────────────────────────────────────────────
+
+    def test_is_not_current_overrides_non_current_status(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="won")
+        self._run(interaction, get_roll_return=roll, is_not_current=True)
+        roll.set_status.assert_called_once_with("failed")
+
+    def test_is_not_current_still_posts_casino_message(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="removed")
+        mock_send = self._run(interaction, get_roll_return=roll, is_not_current=True)
+        mock_send.assert_awaited_once()
+
+    # ── casino message routing ────────────────────────────────────────────────
+
+    def test_solo_roll_looks_up_only_main_user(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="current", partner_ce_id=None)
+        with (
+            patch("commands.admin.SupabaseReader.get_roll", return_value=roll),
+            patch("commands.admin.SupabaseReader.dump_roll"),
+            patch("commands.admin.hm.log_command", new_callable=AsyncMock),
+            patch("commands.admin.hm.send_message", new_callable=AsyncMock),
+            patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
+            patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()) as mock_get_user,
+        ):
+            import commands.admin as admin_mod
+            with patch.object(admin_mod, "client", create=True, new=MagicMock()):
+                asyncio.run(fail_roll(interaction, "roll-001", False))
+        mock_get_user.assert_called_once_with(roll.user_ce_id)
+
+    def test_co_op_roll_looks_up_both_users(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="current", partner_ce_id="partner-001")
+        with (
+            patch("commands.admin.SupabaseReader.get_roll", return_value=roll),
+            patch("commands.admin.SupabaseReader.dump_roll"),
+            patch("commands.admin.hm.log_command", new_callable=AsyncMock),
+            patch("commands.admin.hm.send_message", new_callable=AsyncMock),
+            patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
+            patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()) as mock_get_user,
+        ):
+            import commands.admin as admin_mod
+            with patch.object(admin_mod, "client", create=True, new=MagicMock()):
+                asyncio.run(fail_roll(interaction, "roll-001", False))
+        called_ids = {c[0][0] for c in mock_get_user.call_args_list}
+        assert roll.user_ce_id in called_ids
+        assert "partner-001" in called_ids
+
+    def test_user_not_found_sends_fallback_casino_message(self):
+        interaction = self._make_interaction()
+        roll = self._make_roll(status="current")
+        with (
+            patch("commands.admin.SupabaseReader.get_roll", return_value=roll),
+            patch("commands.admin.SupabaseReader.dump_roll"),
+            patch("commands.admin.hm.log_command", new_callable=AsyncMock),
+            patch("commands.admin.hm.send_message", new_callable=AsyncMock) as mock_send,
+            patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
+            patch("commands.admin.SupabaseReader.get_user", return_value=None),
+        ):
+            import commands.admin as admin_mod
+            with patch.object(admin_mod, "client", create=True, new=MagicMock()):
+                asyncio.run(fail_roll(interaction, "roll-001", False))
+        _, channel, msg = mock_send.call_args[0]
+        assert channel == "casino"
+        assert "not found" in msg.lower()

--- a/tests/unit/test_admin_commands.py
+++ b/tests/unit/test_admin_commands.py
@@ -151,11 +151,17 @@ class TestFailRoll:
         with (
             patch.object(admin_mod, "client", create=True, new=MagicMock()),
             patch("commands.admin.hm.log_command", new_callable=AsyncMock),
-            patch("commands.admin.hm.send_message", new_callable=AsyncMock) as mock_send,
-            patch("commands.admin.SupabaseReader.get_roll", return_value=get_roll_return),
+            patch(
+                "commands.admin.hm.send_message", new_callable=AsyncMock
+            ) as mock_send,
+            patch(
+                "commands.admin.SupabaseReader.get_roll", return_value=get_roll_return
+            ),
             patch("commands.admin.SupabaseReader.dump_roll"),
             patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
-            patch("commands.admin.SupabaseReader.get_user", side_effect=get_user_return),
+            patch(
+                "commands.admin.SupabaseReader.get_user", side_effect=get_user_return
+            ),
         ):
             asyncio.run(fail_roll(interaction, roll_id, is_not_current))
             return mock_send
@@ -179,6 +185,7 @@ class TestFailRoll:
             patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()),
         ):
             import commands.admin as admin_mod
+
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
                 asyncio.run(fail_roll(interaction, "bad-id", False))
         mock_dump.assert_not_called()
@@ -211,6 +218,7 @@ class TestFailRoll:
             patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()),
         ):
             import commands.admin as admin_mod
+
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
                 asyncio.run(fail_roll(interaction, "roll-001", False))
         mock_dump.assert_not_called()
@@ -235,6 +243,7 @@ class TestFailRoll:
             patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()),
         ):
             import commands.admin as admin_mod
+
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
                 asyncio.run(fail_roll(interaction, "roll-001", False))
         mock_dump.assert_called_once_with(roll)
@@ -280,9 +289,12 @@ class TestFailRoll:
             patch("commands.admin.hm.log_command", new_callable=AsyncMock),
             patch("commands.admin.hm.send_message", new_callable=AsyncMock),
             patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
-            patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()) as mock_get_user,
+            patch(
+                "commands.admin.SupabaseReader.get_user", return_value=MagicMock()
+            ) as mock_get_user,
         ):
             import commands.admin as admin_mod
+
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
                 asyncio.run(fail_roll(interaction, "roll-001", False))
         mock_get_user.assert_called_once_with(roll.user_ce_id)
@@ -296,9 +308,12 @@ class TestFailRoll:
             patch("commands.admin.hm.log_command", new_callable=AsyncMock),
             patch("commands.admin.hm.send_message", new_callable=AsyncMock),
             patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
-            patch("commands.admin.SupabaseReader.get_user", return_value=MagicMock()) as mock_get_user,
+            patch(
+                "commands.admin.SupabaseReader.get_user", return_value=MagicMock()
+            ) as mock_get_user,
         ):
             import commands.admin as admin_mod
+
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
                 asyncio.run(fail_roll(interaction, "roll-001", False))
         called_ids = {c[0][0] for c in mock_get_user.call_args_list}
@@ -312,11 +327,14 @@ class TestFailRoll:
             patch("commands.admin.SupabaseReader.get_roll", return_value=roll),
             patch("commands.admin.SupabaseReader.dump_roll"),
             patch("commands.admin.hm.log_command", new_callable=AsyncMock),
-            patch("commands.admin.hm.send_message", new_callable=AsyncMock) as mock_send,
+            patch(
+                "commands.admin.hm.send_message", new_callable=AsyncMock
+            ) as mock_send,
             patch("commands.admin.SupabaseReader.get_database_name", return_value=[]),
             patch("commands.admin.SupabaseReader.get_user", return_value=None),
         ):
             import commands.admin as admin_mod
+
             with patch.object(admin_mod, "client", create=True, new=MagicMock()):
                 asyncio.run(fail_roll(interaction, "roll-001", False))
         _, channel, msg = mock_send.call_args[0]


### PR DESCRIPTION
New command `/fail-roll`:
- Takes in a Roll ID and sets the status to 'failed' if the status is 'current'.
- That can be overridden with the optional 'is_not_current' boolean flag.