### PR TITLE
feature: /profile gets a tier/category summary image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ docs/
 .superpowers
 .superpowers/sdd/review-final.diff
 data/
+Assets/emoji_cache/

--- a/Modules/Discord_Helper.py
+++ b/Modules/Discord_Helper.py
@@ -14,6 +14,7 @@ import logging
 # -- local --
 from Classes.CE_Roll import CERoll
 import Modules.hm as hm
+from Modules import ProfileChart
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -247,13 +248,17 @@ class ProfileView(discord.ui.View):
 
 async def get_user_embeds(
     user: CEUser, database_name: list[CEGame]
-) -> tuple[discord.Embed, discord.ui.View]:
+) -> tuple[discord.Embed, discord.ui.View, discord.File | None]:
     """Returns a `discord.Embed` that represents this user."""
 
     # pull api data
     api_user = await user.get_api_user()
     if api_user is None:
-        return (discord.Embed(title="Error!"), discord.ui.View())
+        return (discord.Embed(title="Error!"), discord.ui.View(), None)
+
+    # build the completions chart image
+    chart_buffer = await ProfileChart.generate_completions_chart(api_user)
+    chart_file = discord.File(chart_buffer, filename="completions.png")
 
     # -- two embeds: summary, completions --
     # summary
@@ -278,9 +283,7 @@ async def get_user_embeds(
         value=user.get_cr(database_name=database_name).cr_string(),
         inline=False,
     )
-    summary_embed.add_field(
-        name="Completions", value=api_user.tier_genre_summary_str(), inline=False
-    )
+    summary_embed.set_image(url="attachment://completions.png")
 
     # recent
     recent_embed = discord.Embed(
@@ -293,4 +296,4 @@ async def get_user_embeds(
         name="Monthly Breakdown", value=api_user.monthly_report_str()
     )
 
-    return (summary_embed, ProfileView(summary_embed, recent_embed))
+    return (summary_embed, ProfileView(summary_embed, recent_embed), chart_file)

--- a/Modules/ProfileChart.py
+++ b/Modules/ProfileChart.py
@@ -4,6 +4,7 @@ pasted below each bar instead of text labels."""
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 from typing import TYPE_CHECKING
@@ -78,20 +79,26 @@ def category_counts(api_user: "CEAPIUser") -> list[tuple[str, int]]:
         genre_name = hm.genre_id_to_name(row["genreId"])
         if genre_name in totals:
             totals[genre_name] = row["total"]
+        elif genre_name != "Total":
+            logger.warning(
+                "Unknown genreId %r (resolved name %r) encountered while "
+                "computing category counts; skipping row",
+                row["genreId"],
+                genre_name,
+            )
     return [(label, totals[label]) for label in CATEGORY_ORDER]
 
 
 async def _emoji_paths_for(labels: list[str]):
-    paths = []
-    for label in labels:
+    async def _fetch(label: str):
         markup = hm.get_emoji(label)  # type: ignore
         try:
-            path = await get_cached_emoji_path(markup)
-            paths.append(path)
+            return await get_cached_emoji_path(markup)
         except Exception:
             logger.exception("Failed to fetch cached emoji path for label %r", label)
-            paths.append(None)
-    return paths
+            return None
+
+    return await asyncio.gather(*(_fetch(label) for label in labels))
 
 
 def _draw_panel(
@@ -152,18 +159,16 @@ def _draw_panel(
                 logger.exception("Failed to paste emoji from path %r", emoji_path)
 
 
-async def generate_completions_chart(api_user: "CEAPIUser") -> io.BytesIO:
-    """Renders the Tiers + Categories completions bar chart and returns a
-    PNG-encoded BytesIO buffer ready for Discord upload."""
-    tiers = tier_counts(api_user)
-    categories = category_counts(api_user)
-
-    tier_colors = [TIER_COLORS[label] for label, _ in tiers]
-    category_colors = [CATEGORY_BAR_COLOR for _ in categories]
-
-    tier_emoji_paths = await _emoji_paths_for([label for label, _ in tiers])
-    category_emoji_paths = await _emoji_paths_for([label for label, _ in categories])
-
+def _render_image(
+    tiers: list[tuple[str, int]],
+    categories: list[tuple[str, int]],
+    tier_colors: list[tuple[int, int, int]],
+    category_colors: list[tuple[int, int, int]],
+    tier_emoji_paths: list,
+    category_emoji_paths: list,
+) -> io.BytesIO:
+    """Synchronous Pillow rendering work (image creation, panel drawing,
+    PNG encoding). Meant to be run off the event loop via asyncio.to_thread."""
     image = Image.new("RGB", (IMAGE_WIDTH, IMAGE_HEIGHT), BACKGROUND_COLOR)
     draw = ImageDraw.Draw(image)
 
@@ -184,3 +189,26 @@ async def generate_completions_chart(api_user: "CEAPIUser") -> io.BytesIO:
     image.save(buffer, format="PNG")
     buffer.seek(0)
     return buffer
+
+
+async def generate_completions_chart(api_user: "CEAPIUser") -> io.BytesIO:
+    """Renders the Tiers + Categories completions bar chart and returns a
+    PNG-encoded BytesIO buffer ready for Discord upload."""
+    tiers = tier_counts(api_user)
+    categories = category_counts(api_user)
+
+    tier_colors = [TIER_COLORS[label] for label, _ in tiers]
+    category_colors = [CATEGORY_BAR_COLOR for _ in categories]
+
+    tier_emoji_paths = await _emoji_paths_for([label for label, _ in tiers])
+    category_emoji_paths = await _emoji_paths_for([label for label, _ in categories])
+
+    return await asyncio.to_thread(
+        _render_image,
+        tiers,
+        categories,
+        tier_colors,
+        category_colors,
+        tier_emoji_paths,
+        category_emoji_paths,
+    )

--- a/Modules/ProfileChart.py
+++ b/Modules/ProfileChart.py
@@ -33,18 +33,17 @@ CATEGORY_ORDER = [
 _TIER_FIELD_NAMES = ["tier1", "tier2", "tier3", "tier4", "tier5"]
 
 # ------------- layout constants -------------
-IMAGE_WIDTH = 800
+IMAGE_WIDTH = 250
 TOP_MARGIN = 20
-TITLE_HEIGHT = 30
-BAR_AREA_HEIGHT = 150
-EMOJI_SIZE = 40
-EMOJI_MARGIN = 10
-PANEL_HEIGHT = TITLE_HEIGHT + BAR_AREA_HEIGHT + EMOJI_MARGIN + EMOJI_SIZE
-PANEL_GAP = 20
+BAR_AREA_HEIGHT = 40
+EMOJI_SIZE = 25
+EMOJI_MARGIN = 20
+PANEL_HEIGHT =  BAR_AREA_HEIGHT + EMOJI_MARGIN + EMOJI_SIZE
+PANEL_GAP = 40
 IMAGE_HEIGHT = TOP_MARGIN + PANEL_HEIGHT + PANEL_GAP + PANEL_HEIGHT + TOP_MARGIN
 
-BAR_MAX_WIDTH = 70
-COUNT_TEXT_GAP = 22
+BAR_MAX_WIDTH = 40
+COUNT_TEXT_GAP = 15
 
 # ------------- color constants -------------
 BACKGROUND_COLOR = (17, 17, 17)
@@ -110,12 +109,9 @@ def _draw_panel(
     emoji_paths: list,
     top_y: int,
 ) -> None:
-    font_title = ImageFont.load_default(size=20)
-    font_count = ImageFont.load_default(size=16)
+    font_count = ImageFont.load_default(size=10)
 
-    draw.text((TOP_MARGIN, top_y), title, font=font_title, fill=TEXT_COLOR)
-
-    axis_y = top_y + TITLE_HEIGHT + BAR_AREA_HEIGHT
+    axis_y = top_y + BAR_AREA_HEIGHT
     n = len(entries)
     slot_width = IMAGE_WIDTH / n
     bar_width = min(BAR_MAX_WIDTH, slot_width * 0.6)
@@ -127,16 +123,19 @@ def _draw_panel(
         bar_top = axis_y - bar_height
 
         if bar_height > 0:
-            draw.rectangle(
+            # -- the actual bar -------
+            draw.rounded_rectangle(
                 [
                     slot_center - bar_width / 2,
                     bar_top,
                     slot_center + bar_width / 2,
                     axis_y,
                 ],
+                radius=3,
                 fill=colors[i],
             )
 
+        # -- the count that goes on top of the bar -----------
         count_text = str(count)
         text_width = draw.textlength(count_text, font=font_count)
         draw.text(
@@ -157,6 +156,18 @@ def _draw_panel(
                 image.paste(emoji_image, (paste_x, paste_y), emoji_image)
             except Exception:
                 logger.exception("Failed to paste emoji from path %r", emoji_path)
+    
+    # -- the x axis bar -------
+    draw.rounded_rectangle(
+        [
+            10,
+            axis_y + EMOJI_MARGIN - 12,
+            IMAGE_WIDTH - 10,
+            axis_y + EMOJI_MARGIN - 8
+        ],
+        radius=3,
+        fill=(255, 255, 255)
+    )
 
 
 def _render_image(

--- a/Modules/ProfileChart.py
+++ b/Modules/ProfileChart.py
@@ -5,6 +5,7 @@ pasted below each bar instead of text labels."""
 from __future__ import annotations
 
 import io
+import logging
 from typing import TYPE_CHECKING
 
 from PIL import Image, ImageDraw, ImageFont
@@ -12,6 +13,8 @@ from PIL import Image, ImageDraw, ImageFont
 import Modules.hm as hm
 
 from utils.emoji_cache import get_cached_emoji_path
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from Classes.CE_User import CEAPIUser
@@ -82,7 +85,12 @@ async def _emoji_paths_for(labels: list[str]):
     paths = []
     for label in labels:
         markup = hm.get_emoji(label)  # type: ignore
-        paths.append(await get_cached_emoji_path(markup))
+        try:
+            path = await get_cached_emoji_path(markup)
+            paths.append(path)
+        except Exception:
+            logger.exception("Failed to fetch cached emoji path for label %r", label)
+            paths.append(None)
     return paths
 
 
@@ -133,12 +141,15 @@ def _draw_panel(
 
         emoji_path = emoji_paths[i]
         if emoji_path is not None:
-            emoji_image = (
-                Image.open(emoji_path).convert("RGBA").resize((EMOJI_SIZE, EMOJI_SIZE))
-            )
-            paste_x = round(slot_center - EMOJI_SIZE / 2)
-            paste_y = axis_y + EMOJI_MARGIN
-            image.paste(emoji_image, (paste_x, paste_y), emoji_image)
+            try:
+                emoji_image = (
+                    Image.open(emoji_path).convert("RGBA").resize((EMOJI_SIZE, EMOJI_SIZE))
+                )
+                paste_x = round(slot_center - EMOJI_SIZE / 2)
+                paste_y = axis_y + EMOJI_MARGIN
+                image.paste(emoji_image, (paste_x, paste_y), emoji_image)
+            except Exception:
+                logger.exception("Failed to paste emoji from path %r", emoji_path)
 
 
 async def generate_completions_chart(api_user: "CEAPIUser") -> io.BytesIO:

--- a/Modules/ProfileChart.py
+++ b/Modules/ProfileChart.py
@@ -1,0 +1,47 @@
+"""Generates the /profile completions chart: two bar-chart panels (Tiers,
+Categories) rendered as a single PNG, with cached Discord emoji images
+pasted below each bar instead of text labels."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import Modules.hm as hm
+
+if TYPE_CHECKING:
+    from Classes.CE_User import CEAPIUser
+
+TIER_ORDER = ["Tier 1", "Tier 2", "Tier 3", "Tier 4", "Tier 5"]
+CATEGORY_ORDER = [
+    "Action",
+    "Arcade",
+    "Bullet Hell",
+    "First-Person",
+    "Platformer",
+    "Strategy",
+]
+
+_TIER_FIELD_NAMES = ["tier1", "tier2", "tier3", "tier4", "tier5"]
+
+
+def tier_counts(api_user: "CEAPIUser") -> list[tuple[str, int]]:
+    """Returns [("Tier 1", n), ..., ("Tier 5", n)] from the Total row of
+    `api_user.api_tier_summary`. All tiers default to 0 if no Total row exists."""
+    for row in api_user.api_tier_summary:
+        if hm.genre_id_to_name(row["genreId"]) == "Total":
+            return [
+                (label, row[field])
+                for label, field in zip(TIER_ORDER, _TIER_FIELD_NAMES)
+            ]
+    return [(label, 0) for label in TIER_ORDER]
+
+
+def category_counts(api_user: "CEAPIUser") -> list[tuple[str, int]]:
+    """Returns [("Action", n), ..., ("Strategy", n)] in fixed alphabetical
+    order from `api_user.api_tier_summary`. Missing categories default to 0."""
+    totals = {label: 0 for label in CATEGORY_ORDER}
+    for row in api_user.api_tier_summary:
+        genre_name = hm.genre_id_to_name(row["genreId"])
+        if genre_name in totals:
+            totals[genre_name] = row["total"]
+    return [(label, totals[label]) for label in CATEGORY_ORDER]

--- a/Modules/ProfileChart.py
+++ b/Modules/ProfileChart.py
@@ -4,9 +4,14 @@ pasted below each bar instead of text labels."""
 
 from __future__ import annotations
 
+import io
 from typing import TYPE_CHECKING
 
+from PIL import Image, ImageDraw, ImageFont
+
 import Modules.hm as hm
+
+from utils.emoji_cache import get_cached_emoji_path
 
 if TYPE_CHECKING:
     from Classes.CE_User import CEAPIUser
@@ -22,6 +27,32 @@ CATEGORY_ORDER = [
 ]
 
 _TIER_FIELD_NAMES = ["tier1", "tier2", "tier3", "tier4", "tier5"]
+
+# ------------- layout constants -------------
+IMAGE_WIDTH = 800
+TOP_MARGIN = 20
+TITLE_HEIGHT = 30
+BAR_AREA_HEIGHT = 150
+EMOJI_SIZE = 40
+EMOJI_MARGIN = 10
+PANEL_HEIGHT = TITLE_HEIGHT + BAR_AREA_HEIGHT + EMOJI_MARGIN + EMOJI_SIZE
+PANEL_GAP = 20
+IMAGE_HEIGHT = TOP_MARGIN + PANEL_HEIGHT + PANEL_GAP + PANEL_HEIGHT + TOP_MARGIN
+
+BAR_MAX_WIDTH = 70
+COUNT_TEXT_GAP = 22
+
+# ------------- color constants -------------
+BACKGROUND_COLOR = (17, 17, 17)
+TEXT_COLOR = (240, 240, 240)
+CATEGORY_BAR_COLOR = (222, 222, 222)
+TIER_COLORS = {
+    "Tier 1": (0, 188, 99),
+    "Tier 2": (228, 177, 1),
+    "Tier 3": (228, 114, 13),
+    "Tier 4": (230, 68, 52),
+    "Tier 5": (169, 5, 177),
+}
 
 
 def tier_counts(api_user: "CEAPIUser") -> list[tuple[str, int]]:
@@ -45,3 +76,100 @@ def category_counts(api_user: "CEAPIUser") -> list[tuple[str, int]]:
         if genre_name in totals:
             totals[genre_name] = row["total"]
     return [(label, totals[label]) for label in CATEGORY_ORDER]
+
+
+async def _emoji_paths_for(labels: list[str]):
+    paths = []
+    for label in labels:
+        markup = hm.get_emoji(label)  # type: ignore
+        paths.append(await get_cached_emoji_path(markup))
+    return paths
+
+
+def _draw_panel(
+    image: Image.Image,
+    draw: ImageDraw.ImageDraw,
+    title: str,
+    entries: list[tuple[str, int]],
+    colors: list[tuple[int, int, int]],
+    emoji_paths: list,
+    top_y: int,
+) -> None:
+    font_title = ImageFont.load_default(size=20)
+    font_count = ImageFont.load_default(size=16)
+
+    draw.text((TOP_MARGIN, top_y), title, font=font_title, fill=TEXT_COLOR)
+
+    axis_y = top_y + TITLE_HEIGHT + BAR_AREA_HEIGHT
+    n = len(entries)
+    slot_width = IMAGE_WIDTH / n
+    bar_width = min(BAR_MAX_WIDTH, slot_width * 0.6)
+    max_count = max((count for _, count in entries), default=0) or 1
+
+    for i, (_, count) in enumerate(entries):
+        slot_center = slot_width * i + slot_width / 2
+        bar_height = round((count / max_count) * BAR_AREA_HEIGHT) if count else 0
+        bar_top = axis_y - bar_height
+
+        if bar_height > 0:
+            draw.rectangle(
+                [
+                    slot_center - bar_width / 2,
+                    bar_top,
+                    slot_center + bar_width / 2,
+                    axis_y,
+                ],
+                fill=colors[i],
+            )
+
+        count_text = str(count)
+        text_width = draw.textlength(count_text, font=font_count)
+        draw.text(
+            (slot_center - text_width / 2, bar_top - COUNT_TEXT_GAP),
+            count_text,
+            font=font_count,
+            fill=TEXT_COLOR,
+        )
+
+        emoji_path = emoji_paths[i]
+        if emoji_path is not None:
+            emoji_image = (
+                Image.open(emoji_path).convert("RGBA").resize((EMOJI_SIZE, EMOJI_SIZE))
+            )
+            paste_x = round(slot_center - EMOJI_SIZE / 2)
+            paste_y = axis_y + EMOJI_MARGIN
+            image.paste(emoji_image, (paste_x, paste_y), emoji_image)
+
+
+async def generate_completions_chart(api_user: "CEAPIUser") -> io.BytesIO:
+    """Renders the Tiers + Categories completions bar chart and returns a
+    PNG-encoded BytesIO buffer ready for Discord upload."""
+    tiers = tier_counts(api_user)
+    categories = category_counts(api_user)
+
+    tier_colors = [TIER_COLORS[label] for label, _ in tiers]
+    category_colors = [CATEGORY_BAR_COLOR for _ in categories]
+
+    tier_emoji_paths = await _emoji_paths_for([label for label, _ in tiers])
+    category_emoji_paths = await _emoji_paths_for([label for label, _ in categories])
+
+    image = Image.new("RGB", (IMAGE_WIDTH, IMAGE_HEIGHT), BACKGROUND_COLOR)
+    draw = ImageDraw.Draw(image)
+
+    _draw_panel(
+        image, draw, "Tiers", tiers, tier_colors, tier_emoji_paths, TOP_MARGIN
+    )
+    _draw_panel(
+        image,
+        draw,
+        "Categories",
+        categories,
+        category_colors,
+        category_emoji_paths,
+        TOP_MARGIN + PANEL_HEIGHT + PANEL_GAP,
+    )
+
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    buffer.seek(0)
+    return buffer

--- a/commands/user.py
+++ b/commands/user.py
@@ -206,14 +206,16 @@ async def profile(interaction: discord.Interaction, user: discord.User | None = 
                 "Sorry! You are not registered. Please run /register and try again!"
             )
 
-    # get the embed and the view
-    returns = await Discord_Helper.get_user_embeds(
+    # get the embed, view, and chart image
+    summary_embed, view, chart_file = await Discord_Helper.get_user_embeds(
         user=ce_user, database_name=database_name
     )
-    summary_embed = returns[0]
-    view = returns[1]
 
     # and send
+    if chart_file is not None:
+        return await interaction.followup.send(
+            view=view, embed=summary_embed, file=chart_file
+        )
     return await interaction.followup.send(view=view, embed=summary_embed)
 
 

--- a/main.py
+++ b/main.py
@@ -178,6 +178,7 @@ async def on_ready():
         "urllib3",
         "discord",
         "aiohttp",
+        "PIL",
     ]:
         logging.getLogger(name).setLevel(logging.WARNING)
         logger.info("Killed logging for %s.", name)

--- a/tests/unit/test_discord_helper_profile.py
+++ b/tests/unit/test_discord_helper_profile.py
@@ -1,0 +1,99 @@
+import asyncio
+import datetime
+import io
+from unittest.mock import AsyncMock, patch
+
+import discord
+
+from Classes.CE_User import CEAPIUser, CEUser
+from Modules import Discord_Helper
+
+
+def _make_registered_user() -> CEUser:
+    return CEUser(
+        discord_id=100000000000000000,
+        ce_id="user-001-0000-0000-000000000000",
+        owned_games=[],
+        rolls=[],
+        display_name="TestUser",
+        avatar="",
+        last_updated=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+
+def _make_api_user() -> CEAPIUser:
+    return CEAPIUser(
+        discord_id=100000000000000000,
+        ce_id="user-001-0000-0000-000000000000",
+        owned_games=[],
+        rolls=[],
+        full_data={
+            "userTierSummaries": [
+                {
+                    "genreId": "00000000-0000-0000-0000-000000000000",
+                    "tier1": 1,
+                    "tier2": 2,
+                    "tier3": 3,
+                    "tier4": 4,
+                    "tier5": 5,
+                    "total": 15,
+                }
+            ],
+            "userObjectives": [],
+        },
+        display_name="TestUser",
+        avatar="",
+        last_updated=datetime.datetime.now(datetime.timezone.utc),
+    )
+
+
+class TestGetUserEmbeds:
+    def test_returns_three_tuple_with_chart_file(self):
+        user = _make_registered_user()
+        api_user = _make_api_user()
+        fake_chart = io.BytesIO(b"fake-png-bytes")
+
+        with (
+            patch.object(user, "get_api_user", new=AsyncMock(return_value=api_user)),
+            patch(
+                "Modules.Discord_Helper.ProfileChart.generate_completions_chart",
+                new=AsyncMock(return_value=fake_chart),
+            ),
+        ):
+            embed, view, chart_file = asyncio.run(
+                Discord_Helper.get_user_embeds(user=user, database_name=[])
+            )
+
+        assert isinstance(embed, discord.Embed)
+        assert isinstance(view, discord.ui.View)
+        assert isinstance(chart_file, discord.File)
+
+    def test_completions_field_removed_and_image_set(self):
+        user = _make_registered_user()
+        api_user = _make_api_user()
+        fake_chart = io.BytesIO(b"fake-png-bytes")
+
+        with (
+            patch.object(user, "get_api_user", new=AsyncMock(return_value=api_user)),
+            patch(
+                "Modules.Discord_Helper.ProfileChart.generate_completions_chart",
+                new=AsyncMock(return_value=fake_chart),
+            ),
+        ):
+            embed, _, _ = asyncio.run(
+                Discord_Helper.get_user_embeds(user=user, database_name=[])
+            )
+
+        field_names = [f.name for f in embed.fields]
+        assert "Completions" not in field_names
+        assert embed.image.url == "attachment://completions.png"
+
+    def test_returns_none_file_when_api_user_missing(self):
+        user = _make_registered_user()
+
+        with patch.object(user, "get_api_user", new=AsyncMock(return_value=None)):
+            embed, view, chart_file = asyncio.run(
+                Discord_Helper.get_user_embeds(user=user, database_name=[])
+            )
+
+        assert chart_file is None

--- a/tests/unit/test_emoji_cache.py
+++ b/tests/unit/test_emoji_cache.py
@@ -1,0 +1,99 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from utils.emoji_cache import parse_emoji_id, get_cached_emoji_path
+
+
+class TestParseEmojiId:
+    def test_parses_standard_emoji(self):
+        assert parse_emoji_id("<:tier1:1126268393725644810>") == "1126268393725644810"
+
+    def test_parses_animated_emoji(self):
+        assert parse_emoji_id("<a:wiggle:123456789012345678>") == "123456789012345678"
+
+    def test_returns_none_for_non_emoji_string(self):
+        assert parse_emoji_id("not an emoji") is None
+        assert parse_emoji_id("bad-input") is None
+
+
+class _FakeResponse:
+    def __init__(self, status: int, body: bytes):
+        self.status = status
+        self._body = body
+
+    async def read(self) -> bytes:
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+        self.get_calls: list[str] = []
+
+    def get(self, url: str):
+        self.get_calls.append(url)
+        return self._response
+
+
+class TestGetCachedEmojiPath:
+    def test_returns_none_for_unparseable_markup(self, tmp_path):
+        result = asyncio.run(
+            get_cached_emoji_path("bad-input", cache_dir=tmp_path)
+        )
+        assert result is None
+
+    def test_returns_cached_path_without_network_call(self, tmp_path):
+        emoji_id = "1126268393725644810"
+        cached_file = tmp_path / f"{emoji_id}.png"
+        cached_file.write_bytes(b"fake-png-bytes")
+
+        with patch(
+            "utils.emoji_cache.http_session.get_session", new_callable=AsyncMock
+        ) as mock_get_session:
+            result = asyncio.run(
+                get_cached_emoji_path(f"<:tier1:{emoji_id}>", cache_dir=tmp_path)
+            )
+
+        assert result == cached_file
+        mock_get_session.assert_not_called()
+
+    def test_downloads_and_caches_on_miss(self, tmp_path):
+        emoji_id = "1126268393725644810"
+        fake_session = _FakeSession(_FakeResponse(200, b"downloaded-bytes"))
+
+        with patch(
+            "utils.emoji_cache.http_session.get_session",
+            new_callable=AsyncMock,
+            return_value=fake_session,
+        ):
+            result = asyncio.run(
+                get_cached_emoji_path(f"<:tier1:{emoji_id}>", cache_dir=tmp_path)
+            )
+
+        assert result == tmp_path / f"{emoji_id}.png"
+        assert result.read_bytes() == b"downloaded-bytes"
+        assert fake_session.get_calls == [
+            f"https://cdn.discordapp.com/emojis/{emoji_id}.png"
+        ]
+
+    def test_returns_none_on_http_error(self, tmp_path):
+        emoji_id = "1126268393725644810"
+        fake_session = _FakeSession(_FakeResponse(404, b""))
+
+        with patch(
+            "utils.emoji_cache.http_session.get_session",
+            new_callable=AsyncMock,
+            return_value=fake_session,
+        ):
+            result = asyncio.run(
+                get_cached_emoji_path(f"<:tier1:{emoji_id}>", cache_dir=tmp_path)
+            )
+
+        assert result is None
+        assert not (tmp_path / f"{emoji_id}.png").exists()

--- a/tests/unit/test_profile_chart.py
+++ b/tests/unit/test_profile_chart.py
@@ -163,3 +163,39 @@ class TestGenerateCompletionsChart:
         from Modules.ProfileChart import TIER_COLORS
 
         assert TIER_COLORS["Tier 2"] in colors_present  # tallest tier bar (count 9)
+
+    def test_handles_get_cached_emoji_path_exception(self):
+        """Test that get_cached_emoji_path raising an exception doesn't crash chart generation."""
+        api_user = self._make_user_with_counts()
+
+        with patch(
+            "Modules.ProfileChart.get_cached_emoji_path",
+            new_callable=AsyncMock,
+            side_effect=Exception("boom"),
+        ):
+            buffer = asyncio.run(generate_completions_chart(api_user))
+
+        assert isinstance(buffer, io.BytesIO)
+        image = Image.open(buffer)
+        assert image.format == "PNG"
+        assert image.size == (IMAGE_WIDTH, IMAGE_HEIGHT)
+
+    def test_handles_corrupted_emoji_file(self, tmp_path):
+        """Test that a corrupted emoji file doesn't crash chart generation."""
+        api_user = self._make_user_with_counts()
+
+        # Create a corrupted emoji file (garbage bytes, not a real PNG)
+        bad_emoji_path = tmp_path / "bad.png"
+        bad_emoji_path.write_bytes(b"not a real png")
+
+        with patch(
+            "Modules.ProfileChart.get_cached_emoji_path",
+            new_callable=AsyncMock,
+            return_value=bad_emoji_path,
+        ):
+            buffer = asyncio.run(generate_completions_chart(api_user))
+
+        assert isinstance(buffer, io.BytesIO)
+        image = Image.open(buffer)
+        assert image.format == "PNG"
+        assert image.size == (IMAGE_WIDTH, IMAGE_HEIGHT)

--- a/tests/unit/test_profile_chart.py
+++ b/tests/unit/test_profile_chart.py
@@ -82,3 +82,84 @@ class TestCategoryCounts:
             ("Platformer", 0),
             ("Strategy", 0),
         ]
+
+
+import asyncio
+import io
+from unittest.mock import AsyncMock, patch
+
+from PIL import Image
+
+from Modules.ProfileChart import (
+    IMAGE_WIDTH,
+    IMAGE_HEIGHT,
+    BACKGROUND_COLOR,
+    generate_completions_chart,
+)
+
+
+class TestGenerateCompletionsChart:
+    def _make_user_with_counts(self):
+        return _make_api_user(
+            [
+                {
+                    "genreId": TOTAL_GENRE_ID,
+                    "tier1": 4,
+                    "tier2": 9,
+                    "tier3": 2,
+                    "tier4": 0,
+                    "tier5": 1,
+                    "total": 16,
+                },
+                {"genreId": ACTION_GENRE_ID, "total": 7},
+            ]
+        )
+
+    def test_returns_png_of_expected_size(self):
+        api_user = self._make_user_with_counts()
+
+        with patch(
+            "Modules.ProfileChart.get_cached_emoji_path",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            buffer = asyncio.run(generate_completions_chart(api_user))
+
+        assert isinstance(buffer, io.BytesIO)
+        image = Image.open(buffer)
+        assert image.format == "PNG"
+        assert image.size == (IMAGE_WIDTH, IMAGE_HEIGHT)
+
+    def test_background_color_is_near_black(self):
+        api_user = self._make_user_with_counts()
+
+        with patch(
+            "Modules.ProfileChart.get_cached_emoji_path",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            buffer = asyncio.run(generate_completions_chart(api_user))
+
+        image = Image.open(buffer).convert("RGB")
+        # top-left corner should be untouched background
+        assert image.getpixel((0, 0)) == BACKGROUND_COLOR
+
+    def test_draws_a_tier_colored_bar_pixel(self):
+        api_user = self._make_user_with_counts()
+
+        with patch(
+            "Modules.ProfileChart.get_cached_emoji_path",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            buffer = asyncio.run(generate_completions_chart(api_user))
+
+        image = Image.open(buffer).convert("RGB")
+        colors_present = {
+            image.getpixel((x, y))
+            for x in range(0, IMAGE_WIDTH, 4)
+            for y in range(0, IMAGE_HEIGHT, 4)
+        }
+        from Modules.ProfileChart import TIER_COLORS
+
+        assert TIER_COLORS["Tier 2"] in colors_present  # tallest tier bar (count 9)

--- a/tests/unit/test_profile_chart.py
+++ b/tests/unit/test_profile_chart.py
@@ -1,0 +1,84 @@
+from Classes.CE_User import CEAPIUser
+from Modules.ProfileChart import tier_counts, category_counts
+
+TOTAL_GENRE_ID = "00000000-0000-0000-0000-000000000000"
+ACTION_GENRE_ID = "4d43349a-43a8-4755-9d52-41ece63ec5b1"
+ARCADE_GENRE_ID = "ec499226-0913-4db1-890e-093b366bcb3c"
+BULLET_HELL_GENRE_ID = "7f8676fe-4900-400b-9284-c073388d88f7"
+
+
+def _make_api_user(tier_summary: list[dict]) -> CEAPIUser:
+    return CEAPIUser(
+        discord_id=1,
+        ce_id="user-001-0000-0000-000000000000",
+        owned_games=[],
+        rolls=[],
+        full_data={"userTierSummaries": tier_summary},
+        display_name="TestUser",
+        avatar="",
+        last_updated=None,
+    )
+
+
+class TestTierCounts:
+    def test_returns_fixed_tier_order(self):
+        api_user = _make_api_user(
+            [
+                {
+                    "genreId": TOTAL_GENRE_ID,
+                    "tier1": 4,
+                    "tier2": 9,
+                    "tier3": 2,
+                    "tier4": 0,
+                    "tier5": 1,
+                    "total": 16,
+                }
+            ]
+        )
+        assert tier_counts(api_user) == [
+            ("Tier 1", 4),
+            ("Tier 2", 9),
+            ("Tier 3", 2),
+            ("Tier 4", 0),
+            ("Tier 5", 1),
+        ]
+
+    def test_all_zero_when_no_total_row(self):
+        api_user = _make_api_user([])
+        assert tier_counts(api_user) == [
+            ("Tier 1", 0),
+            ("Tier 2", 0),
+            ("Tier 3", 0),
+            ("Tier 4", 0),
+            ("Tier 5", 0),
+        ]
+
+
+class TestCategoryCounts:
+    def test_returns_fixed_alphabetical_order_regardless_of_input_order(self):
+        api_user = _make_api_user(
+            [
+                {"genreId": TOTAL_GENRE_ID, "tier1": 0, "tier2": 0, "tier3": 0, "tier4": 0, "tier5": 0, "total": 0},
+                {"genreId": BULLET_HELL_GENRE_ID, "total": 3},
+                {"genreId": ACTION_GENRE_ID, "total": 7},
+            ]
+        )
+        assert category_counts(api_user) == [
+            ("Action", 7),
+            ("Arcade", 0),
+            ("Bullet Hell", 3),
+            ("First-Person", 0),
+            ("Platformer", 0),
+            ("Strategy", 0),
+        ]
+
+    def test_all_zero_when_no_category_rows(self):
+        api_user = _make_api_user([])
+        assert category_counts(api_user) == [
+            ("Action", 0),
+            ("Arcade", 0),
+            ("Bullet Hell", 0),
+            ("First-Person", 0),
+            ("Platformer", 0),
+            ("Strategy", 0),
+        ]

--- a/tests/unit/test_profile_command.py
+++ b/tests/unit/test_profile_command.py
@@ -1,0 +1,75 @@
+import asyncio
+import io
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+
+from commands.user import profile
+
+
+def _make_interaction(user_id=100000000000000000):
+    return SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+        user=SimpleNamespace(id=user_id, mention=f"<@{user_id}>"),
+    )
+
+
+class TestProfileCommand:
+    def test_forwards_chart_file_to_followup_send(self):
+        interaction = _make_interaction()
+        fake_embed = discord.Embed(title="Profile")
+        fake_view = MagicMock()
+        fake_file = discord.File(
+            io.BytesIO(b"fake-png-bytes"), filename="completions.png"
+        )
+
+        with (
+            patch("commands.user.client", create=True, new=MagicMock()),
+            patch("commands.user.hm.log_command", new_callable=AsyncMock),
+            patch(
+                "commands.user.SupabaseReader.get_database_name", return_value=[]
+            ),
+            patch(
+                "commands.user.SupabaseReader.get_user",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "commands.user.Discord_Helper.get_user_embeds",
+                new=AsyncMock(return_value=(fake_embed, fake_view, fake_file)),
+            ),
+        ):
+            asyncio.run(profile(interaction, None))
+
+        _, kwargs = interaction.followup.send.call_args
+        assert kwargs["file"] is fake_file
+        assert kwargs["embed"] is fake_embed
+        assert kwargs["view"] is fake_view
+
+    def test_sends_without_file_when_none(self):
+        interaction = _make_interaction()
+        fake_embed = discord.Embed(title="Profile")
+        fake_view = MagicMock()
+
+        with (
+            patch("commands.user.client", create=True, new=MagicMock()),
+            patch("commands.user.hm.log_command", new_callable=AsyncMock),
+            patch(
+                "commands.user.SupabaseReader.get_database_name", return_value=[]
+            ),
+            patch(
+                "commands.user.SupabaseReader.get_user",
+                return_value=SimpleNamespace(),
+            ),
+            patch(
+                "commands.user.Discord_Helper.get_user_embeds",
+                new=AsyncMock(return_value=(fake_embed, fake_view, None)),
+            ),
+        ):
+            asyncio.run(profile(interaction, None))
+
+        _, kwargs = interaction.followup.send.call_args
+        assert "file" not in kwargs
+        assert kwargs["embed"] is fake_embed
+        assert kwargs["view"] is fake_view

--- a/utils/emoji_cache.py
+++ b/utils/emoji_cache.py
@@ -1,0 +1,56 @@
+"""Resolves custom Discord emoji markup (e.g. <:tier1:123>) to a locally
+cached PNG file, downloading from Discord's CDN on first use."""
+
+import logging
+import re
+from pathlib import Path
+
+from Modules import http_session
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIR = Path("Assets/emoji_cache")
+
+_EMOJI_PATTERN = re.compile(r"^<a?:\w+:(\d+)>$")
+
+
+def parse_emoji_id(emoji_markup: str) -> str | None:
+    """Extracts the numeric ID out of a `<:name:id>` or `<a:name:id>` emoji string."""
+    match = _EMOJI_PATTERN.match(emoji_markup)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+async def get_cached_emoji_path(
+    emoji_markup: str, cache_dir: Path = CACHE_DIR
+) -> Path | None:
+    """Returns the local path to `emoji_markup`'s PNG, downloading and
+    caching it first if this is the first time it's been requested.
+    Returns None if the markup can't be parsed or the download fails."""
+    emoji_id = parse_emoji_id(emoji_markup)
+    if emoji_id is None:
+        logger.error("Could not parse emoji ID out of %r", emoji_markup)
+        return None
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cached_path = cache_dir / f"{emoji_id}.png"
+    if cached_path.exists():
+        return cached_path
+
+    url = f"https://cdn.discordapp.com/emojis/{emoji_id}.png"
+    try:
+        session = await http_session.get_session()
+        async with session.get(url) as response:
+            if response.status != 200:
+                logger.error(
+                    "Failed to download emoji %s: HTTP %s", emoji_id, response.status
+                )
+                return None
+            data = await response.read()
+    except Exception:
+        logger.exception("Failed to download emoji %s", emoji_id)
+        return None
+
+    cached_path.write_bytes(data)
+    return cached_path


### PR DESCRIPTION
Currently, running `/profile` gets you an output that looks like this:

<img width="114" height="101" alt="Screenshot 2026-07-07 at 9 34 58 AM" src="https://github.com/user-attachments/assets/1d89d2cd-f73c-4535-b6c3-64cb17c27343" />

I'm working on creating an image that goes along with it to display this better.