### PR TITLE
fix(deploy): use systemd --user units so deploy key never needs sudo

### DIFF
--- a/deploy/SETUP.md
+++ b/deploy/SETUP.md
@@ -76,19 +76,35 @@ cd <repo-path-on-vm>
 git checkout main
 ```
 
-## 2. Fill in and install the systemd unit files
+## 2. Fill in and install the systemd **user** unit files
 
-`deploy/ce-bot.service` and `deploy/ce-scraper.service` have three
-placeholders each: `<deploy-user>`, `<repo-path-on-vm>` (appears multiple
-times per file). Replace them with the actual Linux user the bot should run
-as and the absolute path to this repo's clone on the VM (the same path used
-in step 1's forced command), then:
+`deploy/ce-bot.service` and `deploy/ce-scraper.service` are **user** units
+(no `User=` directive, `WantedBy=default.target`), not system units. This is
+deliberate: `scripts/deploy.sh` restarts them via `systemctl --user`, which
+the deploy key can do without any `sudo`/root access at all — the forced
+command from step 1 never needs privilege escalation for anything, which is
+the whole point of restricting it there. Fill in the one placeholder,
+`<repo-path-on-vm>` (appears multiple times per file), with the absolute
+path to this repo's clone on the VM (the same path used in step 1's forced
+command), then, **as the deploy user, no sudo**:
 
 ```bash
-sudo cp deploy/ce-bot.service deploy/ce-scraper.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now ce-bot ce-scraper
-sudo systemctl status ce-bot ce-scraper   # confirm both show "active (running)"
+mkdir -p ~/.config/systemd/user
+cp deploy/ce-bot.service deploy/ce-scraper.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now ce-bot ce-scraper
+systemctl --user status ce-bot ce-scraper   # confirm both show "active (running)"
+```
+
+User units normally only run while that user has an active login session.
+Since this bot must survive reboots and SSH disconnects with nobody logged
+in, enable lingering **once**, as root (this is the one step in this whole
+setup that touches root, and it's a one-time bootstrap action — not
+something the recurring deploy key ever needs to do):
+
+```bash
+sudo loginctl enable-linger <deploy-user>
+loginctl show-user <deploy-user> -p Linger   # confirm "Linger=yes"
 ```
 
 Step 1's forced command already sets `PIP_BIN`/`PYTHON_BIN`/`PYTEST_BIN` to
@@ -121,13 +137,14 @@ Push a trivial commit to `main` (e.g. a comment change) from your dev
 machine and confirm:
 
 - The `Deploy` workflow run appears and goes green in the repo's Actions tab.
-- `sudo systemctl status ce-bot ce-scraper` on the VM shows both `active`
-  and started recently (`systemctl show -p ActiveEnterTimestamp ce-bot`).
+- `systemctl --user status ce-bot ce-scraper` (run as the deploy user, no
+  sudo) on the VM shows both `active` and started recently
+  (`systemctl --user show -p ActiveEnterTimestamp ce-bot`).
 - `git -C <repo-path-on-vm> rev-parse HEAD` on the VM matches the new
   commit's SHA.
 
 Then push one deliberately broken commit (e.g. an unmatched parenthesis in
 `main.py`) to confirm the rollback path: the `Deploy` run should go red,
-but `systemctl status ce-bot ce-scraper` should still show the *previous*
-commit's SHA and both services still `active`. Revert the broken commit
-afterward.
+but `systemctl --user status ce-bot ce-scraper` should still show the
+*previous* commit's SHA and both services still `active`. Revert the broken
+commit afterward.

--- a/deploy/ce-bot.service
+++ b/deploy/ce-bot.service
@@ -5,7 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=<deploy-user>
 WorkingDirectory=<repo-path-on-vm>
 EnvironmentFile=<repo-path-on-vm>/.env
 ExecStart=<repo-path-on-vm>/.venv/bin/python <repo-path-on-vm>/main.py
@@ -13,4 +12,4 @@ Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/deploy/ce-scraper.service
+++ b/deploy/ce-scraper.service
@@ -5,7 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=<deploy-user>
 WorkingDirectory=<repo-path-on-vm>
 EnvironmentFile=<repo-path-on-vm>/.env
 ExecStart=<repo-path-on-vm>/.venv/bin/python <repo-path-on-vm>/scraper_main.py
@@ -13,4 +12,4 @@ Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Deploys main.py and scraper_main.py on the VM: pulls main, reinstalls
-# deps, runs a safety check, restarts the systemd services, and rolls back
-# automatically if the new code fails to import or fails to become healthy.
+# deps, runs a safety check, restarts the systemd --user services, and
+# rolls back automatically if the new code fails to import or fails to
+# become healthy.
 #
-# Invoked by .github/workflows/deploy.yml on a self-hosted GitHub Actions
-# runner registered on the VM. See docs/superpowers/specs (local, gitignored)
-# for the full design rationale, and deploy/SETUP.md for one-time VM setup.
+# Invoked over SSH by .github/workflows/deploy.yml (GitHub-hosted runner),
+# via a forced-command deploy key that never needs sudo -- ce-bot/ce-scraper
+# are systemd --user units for exactly this reason. See docs/superpowers/specs
+# (local, gitignored) for the full design rationale, and deploy/SETUP.md for
+# one-time VM setup.
 set -euo pipefail
 
 REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
@@ -25,13 +28,13 @@ rollback() {
     log "Rolling back to $prev_sha"
     git reset --hard "$prev_sha"
     "$PIP_BIN" install -r requirements.txt
-    systemctl restart "${SERVICES[@]}"
+    systemctl --user restart "${SERVICES[@]}"
 }
 
 services_healthy() {
     local svc
     for svc in "${SERVICES[@]}"; do
-        if [[ "$(systemctl is-active "$svc")" != "active" ]]; then
+        if [[ "$(systemctl --user is-active "$svc")" != "active" ]]; then
             return 1
         fi
     done
@@ -64,7 +67,7 @@ main() {
     fi
 
     log "Restarting services: ${SERVICES[*]}"
-    systemctl restart "${SERVICES[@]}"
+    systemctl --user restart "${SERVICES[@]}"
 
     # Poll HEALTH_CHECK_RETRIES times, sleeping HEALTH_CHECK_INTERVAL seconds
     # before *each* check (including the first). A Type=simple systemd unit

--- a/tests/deploy/test_deploy_functions.sh
+++ b/tests/deploy/test_deploy_functions.sh
@@ -19,6 +19,9 @@ setup_stub_bin() {
 # Stub systemctl. Records calls to $STUB_LOG. "is-active" reads desired
 # state from $STUB_ACTIVE_SERVICES (space-separated list of active units).
 echo "$*" >> "$STUB_LOG"
+if [[ "$1" == "--user" ]]; then
+    shift
+fi
 if [[ "$1" == "is-active" ]]; then
     svc="$2"
     for active in $STUB_ACTIVE_SERVICES; do
@@ -133,10 +136,10 @@ test_rollback_resets_and_restarts() {
             fail "rollback: expected pip install -r requirements.txt to be called"
         fi
 
-        if grep -q "^restart ce-bot ce-scraper$" "$STUB_LOG"; then
+        if grep -q "^--user restart ce-bot ce-scraper$" "$STUB_LOG"; then
             pass "rollback: restarted services"
         else
-            fail "rollback: expected systemctl restart ce-bot ce-scraper to be called"
+            fail "rollback: expected systemctl --user restart ce-bot ce-scraper to be called"
         fi
     )
     rm -rf "$tmp"

--- a/tests/deploy/test_deploy_main.sh
+++ b/tests/deploy/test_deploy_main.sh
@@ -64,6 +64,9 @@ setup_fixture() {
     cat > "$bin/systemctl" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >> "$tmp/log"
+if [[ "\$1" == "--user" ]]; then
+    shift
+fi
 if [[ "\$1" == "restart" ]]; then
     exit 0
 fi
@@ -167,7 +170,7 @@ test_smoke_test_failure_rolls_back() {
     # here -- it's the rollback's restart, not a restart with broken v2 code.
     # main()'s own success-path restart never fires because it returns via
     # `rollback; exit 1` before reaching `systemctl restart` for the deploy.
-    restart_count="$(grep -c "^restart ce-bot ce-scraper$" "$tmp/log" || true)"
+    restart_count="$(grep -c "^--user restart ce-bot ce-scraper$" "$tmp/log" || true)"
     if [[ "$restart_count" -eq 1 ]]; then
         pass "smoke failure: services only restarted once, by rollback with reverted code"
     else
@@ -218,6 +221,9 @@ test_crashes_shortly_after_start_rolls_back() {
     cat > "$tmp/bin/systemctl" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >> "$tmp/log"
+if [[ "\$1" == "--user" ]]; then
+    shift
+fi
 if [[ "\$1" == "restart" ]]; then
     exit 0
 fi


### PR DESCRIPTION
Discovered live during VM setup: systemctl restart on the system-level units failed with "Interactive authentication required" when run over a non-interactive SSH session, since the deploy user has no passwordless sudo. Rather than granting sudo to a key that's already restricted to a forced command (widening its privilege back out), move ce-bot/ce-scraper to systemd --user units, which the deploy user can manage with zero privilege escalation. Requires one-time `loginctl enable-linger` (root, run once during setup, not by the recurring deploy key) so user units survive reboots/logout. Updated deploy.sh, both unit files, and their tests accordingly; all still pass (5/5, 9/9, 1574 pytest).