### PR TITLE
fix(deploy): re-exec after pull so self-updates take effect same-run

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -42,12 +42,30 @@ services_healthy() {
 }
 
 main() {
-    local prev_sha attempt
-    prev_sha="$(git rev-parse HEAD)"
+    # bash reads a small script file into memory up front, so a process
+    # already executing this file doesn't notice `git reset --hard`
+    # replacing scripts/deploy.sh on disk mid-run -- it keeps running
+    # whatever it already had buffered. Concretely: this bit (DEPLOY_PREV_SHA
+    # unset) only runs once, on the process the SSH forced command actually
+    # launched, which may be an *old* copy of this script. It does the pull,
+    # then hands off via `exec` to a brand-new bash process that re-reads
+    # the file fresh off disk -- so every line of orchestration logic after
+    # the pull always reflects the just-pulled version of this script, not
+    # whatever was on disk when the SSH connection first came in.
+    if [[ -z "${DEPLOY_PREV_SHA:-}" ]]; then
+        local prev_sha
+        prev_sha="$(git rev-parse HEAD)"
 
-    log "Fetching origin/main"
-    git fetch origin main
-    git reset --hard origin/main
+        log "Fetching origin/main"
+        git fetch origin main
+        git reset --hard origin/main
+
+        export DEPLOY_PREV_SHA="$prev_sha"
+        exec bash "$REPO_DIR/scripts/deploy.sh"
+    fi
+
+    local prev_sha="$DEPLOY_PREV_SHA"
+    unset DEPLOY_PREV_SHA
 
     log "Installing dependencies"
     "$PIP_BIN" install -r requirements.txt
@@ -76,8 +94,7 @@ main() {
     # checking immediately with no grace period would let that slip through
     # as a false positive. Success is determined only by whether the last
     # check in the window is healthy, not by the first "active" reading.
-    local healthy=0
-    attempt=0
+    local healthy=0 attempt=0
     while (( attempt < HEALTH_CHECK_RETRIES )); do
         sleep "$HEALTH_CHECK_INTERVAL"
         attempt=$((attempt + 1))

--- a/tests/deploy/test_deploy_main.sh
+++ b/tests/deploy/test_deploy_main.sh
@@ -32,7 +32,13 @@ setup_fixture() {
         echo "requests" > requirements.txt
         mkdir -p scripts
         echo '#!/usr/bin/env true' > scripts/smoke_test_imports.py
-        git add requirements.txt scripts/smoke_test_imports.py
+        # deploy.sh re-execs itself as "$REPO_DIR/scripts/deploy.sh" after
+        # pulling (see the DEPLOY_PREV_SHA re-exec in main()), so the fixture
+        # repo needs its own copy of the real script at that path for the
+        # re-exec'd process to find -- otherwise it'd only exist at
+        # $REPO_ROOT, not inside this synthetic $work checkout.
+        cp "$REPO_ROOT/scripts/deploy.sh" scripts/deploy.sh
+        git add requirements.txt scripts/smoke_test_imports.py scripts/deploy.sh
         git commit -q -m "v1 (good)"
         git push -q origin main 2>/dev/null || git push -q origin master
     )


### PR DESCRIPTION
Root cause of the "Interactive authentication required" failure seen on the first real deploy run: bash reads a script file into memory once at process start, so a process already executing scripts/deploy.sh doesn't notice `git reset --hard` replacing that same file on disk mid-run -- it keeps running whatever orchestration logic it already had loaded. This is why pytest correctly ran against the newly-pulled Python source (pytest reads .py files fresh at its own runtime) while the restart step still used the pre-pull `systemctl restart` (no --user) despite the fix already being on origin/main.

This was a one-time issue for that specific transition, since the next invocation starts as a brand-new process reading the now-current file -- but the same class of bug would recur on every future change to deploy.sh's own orchestration logic. Fixed structurally: after the pull, main() now hands off via `exec` to a fresh bash process that re-reads the just-pulled script off disk, so every future self-change takes effect within the same run, not just the run after.

Verified against the actual regression (reproduced the exact bug with an old-style script pulling the fix mid-run) and against a simulated future change (a mid-run edit to deploy.sh's own log line was picked up correctly). tests/deploy/test_deploy_main.sh's fixture now commits a real copy of scripts/deploy.sh so the re-exec has something to find.