### PR TITLE
feat: add --dev flag to main.py to run against the test guild

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,13 @@
 # -------- discord imports -----------
+import os
+import sys
+
+# Must happen before any import that touches utils.channels (which computes
+# IN_CE-dependent constants once, at import time) -- `from Modules import hm`
+# below is that first import, via `from utils.channels import *`.
+if "--dev" in sys.argv:
+    os.environ["CE_DEV_MODE"] = "1"
+
 import logging
 
 from Modules import hm
@@ -11,8 +20,6 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
-
-import os  # noqa: E402
 
 # -------- json imports ----------
 from typing import Literal  # noqa: E402

--- a/utils/channels.py
+++ b/utils/channels.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Literal
 
 import aiohttp
@@ -6,7 +7,10 @@ import discord
 
 logger = logging.getLogger(__name__)
 
-IN_CE = True
+# main.py sets CE_DEV_MODE=1 (before importing anything that depends on
+# IN_CE) when run with `--dev`, to run against the test guild/channels
+# instead of the real CE server.
+IN_CE = os.environ.get("CE_DEV_MODE") != "1"
 
 CE_CHANNELS = {
     "gameadditions": 949482536726298666,


### PR DESCRIPTION
utils/channels.py's IN_CE now reads from CE_DEV_MODE (defaulting to True, same as before, so CI's `IN_CE is True` check and normal production runs are unaffected). main.py sets CE_DEV_MODE=1 before any IN_CE-dependent import when invoked with `python3 main.py --dev`, so it picks up the test guild/channels and DISCORD_BOT_TOKEN_TERTIARY /DISCORD_TEST_GUILD_ID that main.py's existing IN_CE branch already supported but previously had no way to reach without editing utils/channels.py by hand.