### PR TITLE
feature: better /profile "recent" string

### DIFF
--- a/Classes/CE_User.py
+++ b/Classes/CE_User.py
@@ -682,7 +682,7 @@ class CEAPIUser(CEUser):
 
             # add to the return string
             return_str += (
-                f"{objective.type_short} {objective.name} ({objective.user_points} {hm.get_emoji('Points')})\n"
+                f"{objective.type_short} '{objective.name}' ({objective.user_points} {hm.get_emoji('Points')})\n"
                 f"- [{game_name}](https://cedb.me/game/{objective.game_ce_id})\n"
                 f"- <t:{completed_at_ts}>\n"
             )

--- a/Classes/CE_User.py
+++ b/Classes/CE_User.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, cast
 
 import aiohttp
 
+from Classes.CE_User_Objective import CEUserObjective
 import Modules.hm as hm
 from Classes.CE_Game import CEGame
 from Classes.CE_Roll import CERoll
@@ -598,8 +599,21 @@ class CEAPIUser(CEUser):
     def api_tier_summary(self) -> list:
         return self.full_data["userTierSummaries"]
 
-    def most_recent_objectives(self):
-        "Returns a list of `CEObjective`s."
+    def most_recent_objectives(self) -> None | list[tuple[CEUserObjective | str, datetime.datetime, str]]:
+        """
+        Grabs a list of the user's NUM_OF_OBJECTIVES's most recently completed `CEUserObjectives`s.
+
+        If the user has completed less than that, this will return `None`.
+
+        Returns
+        ---
+        objective: `CEUserObjective`
+            The actual original CEUserObjective object
+        completed_at: `datetime.datetime`
+            The most recent `updatedAt` value for this userObjective.
+        game_name: `str`
+            The name of the game the objective is associated with.
+        """
 
         # make a constant
         NUM_OF_OBJECTIVES = 3
@@ -648,7 +662,7 @@ class CEAPIUser(CEUser):
         # pull the data
         objective_tuples = self.most_recent_objectives()
         if objective_tuples is None:
-            return "Database out of sync! if this continues ping andy"
+            return f"Complete more objectives to unlock this screen!"
 
         # set up return
         return_str: str = ""
@@ -656,19 +670,21 @@ class CEAPIUser(CEUser):
         # loop!
         for item in objective_tuples:
             # pull the actual items from the tuple
-            objective = item[0]
-            game_name = item[2]
+            objective, completed_at, game_name = item
+
+            completed_at_ts = int(completed_at.timestamp())
 
             if isinstance(objective, str):
                 return_str += (
-                    f"Error, please ping andy. obj: {objective} game: {game_name}\n"
+                    f"Please wait for next DB sync - {game_name} - <t:{completed_at_ts}>\n"
                 )
                 continue
 
             # add to the return string
             return_str += (
-                f"{objective.name} ({objective.user_points} {hm.get_emoji('Points')}) "
-                + f"- [{game_name}](https://cedb.me/game/{objective.game_ce_id}/)\n"
+                f"[{game_name}](https://cedb.me/game/{objective.game_ce_id})\n"
+                f"- {objective.type_short} {objective.name} ({objective.user_points} {hm.get_emoji('Points')})\n"
+                f"- <t:{completed_at_ts}>\n"
             )
 
         return return_str

--- a/Classes/CE_User.py
+++ b/Classes/CE_User.py
@@ -682,8 +682,8 @@ class CEAPIUser(CEUser):
 
             # add to the return string
             return_str += (
-                f"[{game_name}](https://cedb.me/game/{objective.game_ce_id})\n"
-                f"- {objective.type_short} {objective.name} ({objective.user_points} {hm.get_emoji('Points')})\n"
+                f"{objective.type_short} {objective.name} ({objective.user_points} {hm.get_emoji('Points')})\n"
+                f"- [{game_name}](https://cedb.me/game/{objective.game_ce_id})\n"
                 f"- <t:{completed_at_ts}>\n"
             )
 

--- a/Classes/CE_User.py
+++ b/Classes/CE_User.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING, cast
 
 import aiohttp
 
-from Classes.CE_User_Objective import CEUserObjective
 import Modules.hm as hm
 from Classes.CE_Game import CEGame
 from Classes.CE_Roll import CERoll
 from Classes.CE_User_Game import CEUserGame
+from Classes.CE_User_Objective import CEUserObjective
 from Classes.OtherClasses import CRData
 from Modules import http_session
 
@@ -599,7 +599,9 @@ class CEAPIUser(CEUser):
     def api_tier_summary(self) -> list:
         return self.full_data["userTierSummaries"]
 
-    def most_recent_objectives(self) -> None | list[tuple[CEUserObjective | str, datetime.datetime, str]]:
+    def most_recent_objectives(
+        self,
+    ) -> None | list[tuple[CEUserObjective | str, datetime.datetime, str]]:
         """
         Grabs a list of the user's NUM_OF_OBJECTIVES's most recently completed `CEUserObjectives`s.
 
@@ -662,7 +664,7 @@ class CEAPIUser(CEUser):
         # pull the data
         objective_tuples = self.most_recent_objectives()
         if objective_tuples is None:
-            return f"Complete more objectives to unlock this screen!"
+            return "Complete more objectives to unlock this screen!"
 
         # set up return
         return_str: str = ""
@@ -675,9 +677,7 @@ class CEAPIUser(CEUser):
             completed_at_ts = int(completed_at.timestamp())
 
             if isinstance(objective, str):
-                return_str += (
-                    f"Please wait for next DB sync - {game_name} - <t:{completed_at_ts}>\n"
-                )
+                return_str += f"Please wait for next DB sync - {game_name} - <t:{completed_at_ts}>\n"
                 continue
 
             # add to the return string

--- a/Classes/CE_User_Objective.py
+++ b/Classes/CE_User_Objective.py
@@ -44,7 +44,7 @@ class CEUserObjective:
     def type(self) -> hm.OBJECTIVE_TYPES:
         """Returns the type of this Objective (e.g. Community, Primary)."""
         return self._type
-    
+
     @property
     def type_short(self) -> str:
         """Returns this as a short type (e.g. PO, SO)"""

--- a/Classes/CE_User_Objective.py
+++ b/Classes/CE_User_Objective.py
@@ -44,6 +44,11 @@ class CEUserObjective:
     def type(self) -> hm.OBJECTIVE_TYPES:
         """Returns the type of this Objective (e.g. Community, Primary)."""
         return self._type
+    
+    @property
+    def type_short(self) -> str:
+        """Returns this as a short type (e.g. PO, SO)"""
+        return f"{self._type[0]}O"
 
     @property
     def game_ce_id(self) -> str:


### PR DESCRIPTION
Added a timestamp and made the /profile string look nicer.

## New version
<img width="382" height="320" alt="Screenshot 2026-07-10 at 3 29 27 PM" src="https://github.com/user-attachments/assets/62b73afb-bbd2-41df-8655-0c159661bdaf" />

## Old version
<img width="645" height="272" alt="Screenshot 2026-07-10 at 3 46 30 PM" src="https://github.com/user-attachments/assets/f6b6b83d-9caf-4ca6-aeee-3e4536fb8955" />
