### PR TITLE
fix: enthusiast roles now have accurate tracking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ beautifulsoup4==4.13.4
 discord.py==2.5.2
 httpx==0.28.1
 motor==3.7.1
-pillow==12.2.0
+pillow==12.3.0
 postgrest==1.1.1
 python-dotenv==1.2.2
 requests==2.33.0

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -1471,34 +1471,38 @@ def check_roles(
     updates: list[UpdateMessageForScraperProcess] = []
 
     for game_old in games_old:
-        points = game_old.user_points
         game_database = hm.get_item_from_list(game_old.ce_id, database_name_old)
 
         if game_database is None:
             continue
 
         # if the game is completed
+        if game_old.is_overcompleted(game_database):
+            old_tiers[game_database.tier_num_include_so - 1] += game_old.user_points
         if game_old.is_completed(game_database):
-            old_tiers[game_database.tier_num - 1] += points
+            old_tiers[game_database.tier_num - 1] += game_old.primary_points
 
         # category roles don't care about completion
+        # PO points only?
         for c_num in game_database.categories_num:
-            old_categories[c_num - 1] += points
+            old_categories[c_num - 1] += game_old.primary_points
 
     for game_new in games_new:
-        points = game_new.user_points
         game_database = hm.get_item_from_list(game_new.ce_id, database_name_new)
 
         if game_database is None:
             continue
 
         # if the game is completed
-        if game_new.is_completed(game_database):
-            new_tiers[game_database.tier_num - 1] += points
+        if game_new.is_overcompleted(game_database):
+            new_tiers[game_database.tier_num_include_so - 1] += game_new.user_points
+        elif game_new.is_completed(game_database):
+            new_tiers[game_database.tier_num - 1] += game_new.primary_points
 
         # category roles don't care about completion
+        # PO points only?
         for c_num in game_database.categories_num:
-            new_categories[c_num - 1] += points
+            new_categories[c_num - 1] += game_new.primary_points
 
     # CATEGORIES
     CATEGORY_ROLE_NAMES = ["Expert", "Master", "Grandmaster"]

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -1502,7 +1502,7 @@ def check_roles(
         # category roles don't care about completion
         # PO points only?
         for c_num in game_database.categories_num:
-            new_categories[c_num - 1] += game_new.primary_points
+            new_categories[c_num - 1] += game_new.user_points
 
     # CATEGORIES
     CATEGORY_ROLE_NAMES = ["Expert", "Master", "Grandmaster"]

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -1497,7 +1497,7 @@ def check_roles(
         if game_new.is_overcompleted(game_database):
             new_tiers[game_database.tier_num_include_so - 1] += game_new.user_points
         elif game_new.is_completed(game_database):
-            new_tiers[game_database.tier_num - 1] += game_new.user_points
+            new_tiers[game_database.tier_num - 1] += game_new.primary_points
 
         # category roles don't care about completion
         # PO points only?

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -1479,13 +1479,13 @@ def check_roles(
         # if the game is completed
         if game_old.is_overcompleted(game_database):
             old_tiers[game_database.tier_num_include_so - 1] += game_old.user_points
-        if game_old.is_completed(game_database):
+        elif game_old.is_completed(game_database):
             old_tiers[game_database.tier_num - 1] += game_old.primary_points
 
         # category roles don't care about completion
         # PO points only?
         for c_num in game_database.categories_num:
-            old_categories[c_num - 1] += game_old.primary_points
+            old_categories[c_num - 1] += game_old.user_points
 
     for game_new in games_new:
         game_database = hm.get_item_from_list(game_new.ce_id, database_name_new)
@@ -1497,7 +1497,7 @@ def check_roles(
         if game_new.is_overcompleted(game_database):
             new_tiers[game_database.tier_num_include_so - 1] += game_new.user_points
         elif game_new.is_completed(game_database):
-            new_tiers[game_database.tier_num - 1] += game_new.primary_points
+            new_tiers[game_database.tier_num - 1] += game_new.user_points
 
         # category roles don't care about completion
         # PO points only?


### PR DESCRIPTION
From the Wiki:

## Tier-specific

These titles / roles are awarded based on points earned from completed games (all primary objectives earned), by Tier.

| Title / Role | Requirement | Colour |
| :----------- | :---- | :---- |
| T1 Enthusiast | Obtain 500+ points from completed T1 games | Green |
| T2 Enthusiast | Obtain 1000+ points from completed T2 games | Yellow |
| T3 Enthusiast | Obtain 1500+ points from completed T3 games | Orange |
| T4 Enthusiast | Obtain 2000+ points from completed T4 games | Red |
| T5 Enthusiast | Obtain 2500+ points from completed T5 (or higher) games | Black |
| Challenge Enthusiast | Obtain all other tier-enthusiast roles | Black |

::: tip Title / Role retention
Once awarded, these titles cannot be lost.  
For example, if a game has a new PO added and moves from Tier 3 to Tier 4, 'T3 Enthusiast' would not be lost.
:::

### Secondary Objectives

For the enthusiast roles, <u>all POs must be completed</u> for a game to be considered completed. This includes games that may have [Secondary Objectives](/general/details/objectives).

For games with SOs, if earning an SO (after having all POs earned) pushes the total earned points in a game above a certain tier, the game will count for that higher tier for the purposes of the enthusiast roles.

::: info FOR EXAMPLE
- [Hollow Knight](https://cedb.me/game/ec1f8e58-b184-496c-a9aa-678876d9dc7b) has one SO worth 150, and POs worth 150.  
   Completing all POs (only) will mean the game contributes to the Tier 4 enthusiast role.  
   Completing the SO will mean the game contributes to the Tier 5 enthusiast role.
- [Garbanzo Quest](https://cedb.me/game/76ee4be2-007a-4df5-a452-a4fb040553e1) has one PO (10), and two SOs (20, 235).  
   Completing the PO and one SO will mean the game counts as a Tier 2, contributing to that enthusiast role.  
   Completing the PO and both SOs will mean the game counts as a Tier 5, contributing to that enthusiast role.  
:::
