### PR TITLE
Regenerate cumulative game-diff message from pre-update snapshot at stabilization

### DIFF
--- a/Modules/SupabaseReader.py
+++ b/Modules/SupabaseReader.py
@@ -510,6 +510,52 @@ def upsert_pending_game_snapshot(game: CEGame) -> None:
         ).execute()
 
 
+def get_pending_game_snapshot_ids() -> set[str]:
+    """Returns the set of ce_ids for all pending games (existence check).
+
+    Used once per scraper loop to avoid re-snapshotting a game that's already mid-cycle.
+    """
+    rows = supabase.table("pendingGame").select("ce_id").execute().data
+    return {r["ce_id"] for r in rows}
+
+
+def get_pending_game_snapshot(ce_id: str) -> CEGame | None:
+    """Reconstructs a full CEGame from the pending snapshot tables.
+
+    Used later to build a cumulative diff. Returns None if the game is not found.
+    """
+    game_rows = (
+        supabase.table("pendingGame").select().eq("ce_id", ce_id).execute().data
+    )
+    if not game_rows:
+        return None
+    game_row = game_rows[0]
+
+    objective_rows = (
+        supabase.table("pendingObjective")
+        .select()
+        .eq("game_ce_id", ce_id)
+        .execute()
+        .data
+    )
+    objective_ids = [o["ce_id"] for o in objective_rows]
+    requirement_rows = []
+    if objective_ids:
+        requirement_rows = (
+            supabase.table("pendingObjectiveRequirement")
+            .select()
+            .in_("objective_ce_id", objective_ids)
+            .execute()
+            .data
+        )
+
+    cats = [
+        {"category": c, "index": i}
+        for i, c in enumerate(game_row.get("categories") or [])
+    ]
+    return __supabase_to_game(game_row, objective_rows, requirement_rows, cats)
+
+
 # === USERS ===
 
 

--- a/Modules/SupabaseReader.py
+++ b/Modules/SupabaseReader.py
@@ -1344,6 +1344,10 @@ def promote_pending_to_stable(ids: list[str]) -> None:
     ).execute()
 
 
+def delete_stale_pending_update(id: str) -> None:
+    supabase.table("scraper_updates").delete().eq("id", id).execute()
+
+
 def upsert_pending_update(update: dict) -> None:
     existing = (
         supabase.table("scraper_updates")

--- a/Modules/SupabaseReader.py
+++ b/Modules/SupabaseReader.py
@@ -524,9 +524,7 @@ def get_pending_game_snapshot(ce_id: str) -> CEGame | None:
 
     Used later to build a cumulative diff. Returns None if the game is not found.
     """
-    game_rows = (
-        supabase.table("pendingGame").select().eq("ce_id", ce_id).execute().data
-    )
+    game_rows = supabase.table("pendingGame").select().eq("ce_id", ce_id).execute().data
     if not game_rows:
         return None
     game_row = game_rows[0]

--- a/Modules/SupabaseReader.py
+++ b/Modules/SupabaseReader.py
@@ -439,6 +439,77 @@ def bulk_dump_games(
             time.sleep(pause_seconds)
 
 
+def upsert_pending_game_snapshot(game: CEGame) -> None:
+    """Writes a full snapshot of a CEGame (game row + its objectives + their requirements)
+    into the three new pending tables.
+
+    Modeled on bulk_dump_games but singular, targeting the pending* tables, and skipping
+    all LocalCache.* calls per the Global Constraints.
+    """
+    now_iso = _now_iso()
+
+    game_row = {
+        "ce_id": game.ce_id,
+        "name": game.game_name,
+        "platform": game.platform,
+        "platform_id": game.platform_id,
+        "category_primary": None,
+        "image_header": game._banner,
+        "image_icon": "",
+        "categories": game.categories,
+        "updated_at_CE": now_iso,
+    }
+    supabase.table("pendingGame").upsert(game_row).execute()
+
+    objective_ids = [o.ce_id for o in game.all_objectives]
+    if not objective_ids:
+        return
+
+    supabase.table("pendingObjectiveRequirement").delete().in_(
+        "objective_ce_id", objective_ids
+    ).execute()
+
+    objectives_payload = []
+    requirements_payload = []
+    for objective in game.all_objectives:
+        objectives_payload.append(
+            {
+                "ce_id": objective.ce_id,
+                "game_ce_id": objective.game_ce_id,
+                "type": objective.type,
+                "name": objective.name,
+                "description": objective.description,
+                "points": objective.point_value,
+                "points_partial": objective.partial_points,
+                "updated_at_CE": now_iso,
+            }
+        )
+        for achievement_id in objective.achievement_ce_ids or []:
+            requirements_payload.append(
+                {
+                    "objective_ce_id": objective.ce_id,
+                    "requirement_type": "achievement",
+                    "data": achievement_id,
+                    "updated_at_CE": now_iso,
+                }
+            )
+        if objective.requirements:
+            requirements_payload.append(
+                {
+                    "objective_ce_id": objective.ce_id,
+                    "requirement_type": "custom",
+                    "data": objective.requirements,
+                    "updated_at_CE": now_iso,
+                }
+            )
+
+    supabase.table("pendingObjective").upsert(objectives_payload).execute()
+    if requirements_payload:
+        supabase.table("pendingObjectiveRequirement").upsert(
+            requirements_payload
+        ).execute()
+
+
 # === USERS ===
 
 

--- a/Modules/SupabaseReader.py
+++ b/Modules/SupabaseReader.py
@@ -1436,6 +1436,22 @@ def delete_game(ce_id: str):
     LocalCache.delete_game_cascade(ce_id)
 
 
+def delete_pending_game_snapshot(ce_id: str) -> None:
+    objectives = (
+        supabase.table("pendingObjective")
+        .select("ce_id")
+        .eq("game_ce_id", ce_id)
+        .execute()
+        .data
+    )
+    for obj in objectives:
+        supabase.table("pendingObjectiveRequirement").delete().eq(
+            "objective_ce_id", obj["ce_id"]
+        ).execute()
+    supabase.table("pendingObjective").delete().eq("game_ce_id", ce_id).execute()
+    supabase.table("pendingGame").delete().eq("ce_id", ce_id).execute()
+
+
 def delete_user(ce_id: str):
     supabase.table("userGames").delete().eq("user_ce_id", ce_id).execute()
     supabase.table("userObjectives").delete().eq("user_ce_id", ce_id).execute()

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,0 +1,26 @@
+# Pending
+Current issue: game stays pending as long as it's considered 'updated'.
+
+## Issue 1: What counts as 'updated'?
+I believe right now, any game with an updatedAt value higher than the last check counts. However, we should
+just be checking to see if an actual UpdateMessageForScraperProcess was made between the new game and the last 
+snapshot.
+
+## Issue 2: Overwriting — IMPLEMENTED
+
+Right now, if a game gets updated, it generates a diff message to be sent to #gameadditions and stores it with
+the unstable flag. Then, on the next check, if somethings changes again, that old diff message gets overwritten.
+
+This one is kind of fine with me right now.
+
+Possible solution: create three new tables: pendingGame, pendingObjective, pendingObjectiveRequirement. When a game
+gets an update (if it's the first, you can check by seeing if the game's id is currently in pendingGame), copy all the
+current data to pendingGame / pendingObjective / pendingObjectiveRequirement. Store the newly updated data in the
+proper tables. Then, keep determining if the game is updated by comparing with the most recently pulled data - 
+which is in the proper game / objective / objectiveRequirement tables. Once that comparison turns up nothing, 
+*then* generate the message by comparing the newly scraped data with the data from the pending* tables, and remove
+that data from those tables.
+
+Implemented per `docs/superpowers/plans/2026-07-15-pending-game-snapshot-diff.md` on branch
+`feature/pending-game-snapshot-diff`. Note: the three Supabase tables above still need to be created manually
+(SQL in the plan doc's "New Supabase Schema" section) before this is live in production.

--- a/tests/unit/test_pending_game_snapshot.py
+++ b/tests/unit/test_pending_game_snapshot.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock, patch
+
+from Modules import SupabaseReader
+from tests.conftest import make_game, make_objective
+
+
+class TestUpsertPendingGameSnapshot:
+    def test_writes_game_row_with_categories(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.upsert.return_value = mock_table
+            mock_table.delete.return_value = mock_table
+            mock_table.in_.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(data=[])
+
+            game = make_game(
+                ce_id="game-001-0000-0000-000000000000",
+                game_name="Test Game",
+                categories=["Action", "Arcade"],
+                objectives=[],
+            )
+            SupabaseReader.upsert_pending_game_snapshot(game)
+
+            game_call = next(
+                c for c in mock_sb.table.call_args_list if c.args[0] == "pendingGame"
+            )
+            assert game_call.args[0] == "pendingGame"
+            inserted = mock_table.upsert.call_args[0][0]
+            assert inserted["ce_id"] == "game-001-0000-0000-000000000000"
+            assert inserted["name"] == "Test Game"
+            assert inserted["categories"] == ["Action", "Arcade"]
+
+    def test_writes_objectives_and_requirements(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.upsert.return_value = mock_table
+            mock_table.delete.return_value = mock_table
+            mock_table.in_.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(data=[])
+
+            objective = make_objective(
+                ce_id="obj-aaaa-0000-0000-000000000000",
+                point_value=10,
+                achievement_ce_ids=["ach-1"],
+                requirements="Beat the boss.",
+            )
+            game = make_game(objectives=[objective])
+            SupabaseReader.upsert_pending_game_snapshot(game)
+
+            tables_written = [c.args[0] for c in mock_sb.table.call_args_list]
+            assert "pendingObjective" in tables_written
+            assert "pendingObjectiveRequirement" in tables_written
+
+    def test_deletes_old_requirements_before_reinserting(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.upsert.return_value = mock_table
+            mock_table.delete.return_value = mock_table
+            mock_table.in_.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(data=[])
+
+            objective = make_objective(ce_id="obj-aaaa-0000-0000-000000000000")
+            game = make_game(objectives=[objective])
+            SupabaseReader.upsert_pending_game_snapshot(game)
+
+            mock_table.delete.assert_any_call()
+            mock_table.in_.assert_any_call(
+                "objective_ce_id", ["obj-aaaa-0000-0000-000000000000"]
+            )
+
+    def test_no_objectives_skips_objective_and_requirement_writes(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.upsert.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(data=[])
+
+            game = make_game(objectives=[])
+            SupabaseReader.upsert_pending_game_snapshot(game)
+
+            tables_written = [c.args[0] for c in mock_sb.table.call_args_list]
+            assert "pendingObjective" not in tables_written
+            assert "pendingObjectiveRequirement" not in tables_written

--- a/tests/unit/test_pending_game_snapshot.py
+++ b/tests/unit/test_pending_game_snapshot.py
@@ -84,3 +84,25 @@ class TestUpsertPendingGameSnapshot:
             tables_written = [c.args[0] for c in mock_sb.table.call_args_list]
             assert "pendingObjective" not in tables_written
             assert "pendingObjectiveRequirement" not in tables_written
+
+    def test_objective_with_no_requirements_skips_requirement_write(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.upsert.return_value = mock_table
+            mock_table.delete.return_value = mock_table
+            mock_table.in_.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(data=[])
+
+            objective = make_objective(
+                ce_id="obj-aaaa-0000-0000-000000000000",
+                achievement_ce_ids=None,
+                requirements=None,
+            )
+            game = make_game(objectives=[objective])
+            SupabaseReader.upsert_pending_game_snapshot(game)
+
+            tables_written = [c.args[0] for c in mock_sb.table.call_args_list]
+            assert "pendingObjective" in tables_written  # objective row still written
+            # only the pre-write delete touches pendingObjectiveRequirement; no upsert
+            assert tables_written.count("pendingObjectiveRequirement") == 1

--- a/tests/unit/test_pending_game_snapshot.py
+++ b/tests/unit/test_pending_game_snapshot.py
@@ -195,3 +195,40 @@ class TestGetPendingGameSnapshot:
             assert result.categories == ["Action"]
             assert len(result.all_objectives) == 1
             assert result.all_objectives[0].ce_id == "obj-aaaa"
+
+
+class TestDeletePendingGameSnapshot:
+    def test_deletes_in_fk_safe_order(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.select.return_value = mock_table
+            mock_table.delete.return_value = mock_table
+            mock_table.eq.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(
+                data=[{"ce_id": "obj-aaaa"}]
+            )
+
+            SupabaseReader.delete_pending_game_snapshot("game-001")
+
+            tables_touched = [c.args[0] for c in mock_sb.table.call_args_list]
+            assert tables_touched == [
+                "pendingObjective",
+                "pendingObjectiveRequirement",
+                "pendingObjective",
+                "pendingGame",
+            ]
+
+    def test_no_objectives_still_deletes_game_row(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.select.return_value = mock_table
+            mock_table.delete.return_value = mock_table
+            mock_table.eq.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(data=[])
+
+            SupabaseReader.delete_pending_game_snapshot("game-001")
+
+            tables_touched = [c.args[0] for c in mock_sb.table.call_args_list]
+            assert "pendingGame" in tables_touched

--- a/tests/unit/test_pending_game_snapshot.py
+++ b/tests/unit/test_pending_game_snapshot.py
@@ -205,9 +205,7 @@ class TestDeletePendingGameSnapshot:
             mock_table.select.return_value = mock_table
             mock_table.delete.return_value = mock_table
             mock_table.eq.return_value = mock_table
-            mock_table.execute.return_value = MagicMock(
-                data=[{"ce_id": "obj-aaaa"}]
-            )
+            mock_table.execute.return_value = MagicMock(data=[{"ce_id": "obj-aaaa"}])
 
             SupabaseReader.delete_pending_game_snapshot("game-001")
 

--- a/tests/unit/test_pending_game_snapshot.py
+++ b/tests/unit/test_pending_game_snapshot.py
@@ -106,3 +106,92 @@ class TestUpsertPendingGameSnapshot:
             assert "pendingObjective" in tables_written  # objective row still written
             # only the pre-write delete touches pendingObjectiveRequirement; no upsert
             assert tables_written.count("pendingObjectiveRequirement") == 1
+
+
+class TestGetPendingGameSnapshotIds:
+    def test_returns_set_of_ce_ids(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.select.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(
+                data=[{"ce_id": "game-001"}, {"ce_id": "game-002"}]
+            )
+
+            result = SupabaseReader.get_pending_game_snapshot_ids()
+
+            mock_sb.table.assert_called_once_with("pendingGame")
+            assert result == {"game-001", "game-002"}
+
+    def test_empty_table_returns_empty_set(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.select.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(data=[])
+
+            result = SupabaseReader.get_pending_game_snapshot_ids()
+
+            assert result == set()
+
+
+class TestGetPendingGameSnapshot:
+    def test_returns_none_when_not_found(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.select.return_value = mock_table
+            mock_table.eq.return_value = mock_table
+            mock_table.execute.return_value = MagicMock(data=[])
+
+            result = SupabaseReader.get_pending_game_snapshot("game-missing")
+
+            assert result is None
+
+    def test_reconstructs_game_with_objectives_and_categories(self):
+        mock_table = MagicMock()
+        with patch.object(SupabaseReader, "supabase") as mock_sb:
+            mock_sb.table.return_value = mock_table
+            mock_table.select.return_value = mock_table
+            mock_table.eq.return_value = mock_table
+
+            mock_table.in_.return_value = mock_table
+
+            game_row = {
+                "ce_id": "game-001",
+                "name": "Test Game",
+                "platform": "steam",
+                "platform_id": "123456",
+                "image_header": "",
+                "categories": ["Action"],
+                "updated_at_CE": "2026-01-01T00:00:00+00:00",
+            }
+            objective_row = {
+                "ce_id": "obj-aaaa",
+                "game_ce_id": "game-001",
+                "type": "Primary",
+                "name": "Test Objective",
+                "description": "desc",
+                "points": 10,
+                "points_partial": 0,
+            }
+
+            def execute_side_effect():
+                table_name = mock_sb.table.call_args[0][0]
+                if table_name == "pendingGame":
+                    return MagicMock(data=[game_row])
+                if table_name == "pendingObjective":
+                    return MagicMock(data=[objective_row])
+                if table_name == "pendingObjectiveRequirement":
+                    return MagicMock(data=[])
+                raise AssertionError(f"unexpected table {table_name}")
+
+            mock_table.execute.side_effect = execute_side_effect
+
+            result = SupabaseReader.get_pending_game_snapshot("game-001")
+
+            assert result is not None
+            assert result.ce_id == "game-001"
+            assert result.categories == ["Action"]
+            assert len(result.all_objectives) == 1
+            assert result.all_objectives[0].ce_id == "obj-aaaa"

--- a/tests/unit/test_scraper_create_update_updated_game.py
+++ b/tests/unit/test_scraper_create_update_updated_game.py
@@ -1070,3 +1070,17 @@ class TestCreateUpdateUpdatedGameObjectiveTypeChanges:
         update, _ = create_update_updated_game(old, new)
         assert update is not None
         assert "Type changed" not in update.description
+
+
+# ── Plain CEGame support ────────────────────────────────────────────────────────
+
+
+class TestCreateUpdateUpdatedGamePlainCEGameSupport:
+    def test_accepts_plain_cegame_for_game_new_and_falls_back_to_banner_image(self):
+        game_old = make_game(objectives=[_po(points=10)])
+        game_new = make_game(objectives=[_po(points=20)])  # plain CEGame, not CEAPIGame
+
+        update, _ = create_update_updated_game(game_old, game_new)
+
+        assert update is not None
+        assert update.image == game_new._banner

--- a/tests/unit/test_should_snapshot_pending_game.py
+++ b/tests/unit/test_should_snapshot_pending_game.py
@@ -1,4 +1,7 @@
-from web_scraper.scraper import UpdateMessageForScraperProcess, should_snapshot_pending_game
+from web_scraper.scraper import (
+    UpdateMessageForScraperProcess,
+    should_snapshot_pending_game,
+)
 
 
 class TestShouldSnapshotPendingGame:
@@ -8,9 +11,7 @@ class TestShouldSnapshotPendingGame:
 
     def test_real_update_with_existing_snapshot_should_not_resnapshot(self):
         update = UpdateMessageForScraperProcess(game_ce_id="game-001")
-        assert (
-            should_snapshot_pending_game("game-001", update, {"game-001"}) is False
-        )
+        assert should_snapshot_pending_game("game-001", update, {"game-001"}) is False
 
     def test_ghost_update_should_not_snapshot(self):
         """update_one_game returned None (no real diff) -- nothing changed,

--- a/tests/unit/test_should_snapshot_pending_game.py
+++ b/tests/unit/test_should_snapshot_pending_game.py
@@ -1,0 +1,18 @@
+from web_scraper.scraper import UpdateMessageForScraperProcess, should_snapshot_pending_game
+
+
+class TestShouldSnapshotPendingGame:
+    def test_real_update_with_no_existing_snapshot_should_snapshot(self):
+        update = UpdateMessageForScraperProcess(game_ce_id="game-001")
+        assert should_snapshot_pending_game("game-001", update, set()) is True
+
+    def test_real_update_with_existing_snapshot_should_not_resnapshot(self):
+        update = UpdateMessageForScraperProcess(game_ce_id="game-001")
+        assert (
+            should_snapshot_pending_game("game-001", update, {"game-001"}) is False
+        )
+
+    def test_ghost_update_should_not_snapshot(self):
+        """update_one_game returned None (no real diff) -- nothing changed,
+        so there's nothing to snapshot."""
+        assert should_snapshot_pending_game("game-001", None, set()) is False

--- a/tests/unit/test_stabilize_pending.py
+++ b/tests/unit/test_stabilize_pending.py
@@ -1,6 +1,11 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from web_scraper.scraper import stabilize_pending_updates
+from tests.conftest import make_game, make_objective
+from web_scraper.scraper import (
+    UpdateMessageForScraperProcess,
+    finalize_stabilized_game_update,
+    stabilize_pending_updates,
+)
 
 
 def _run(pending: list[dict], changed: set[str]) -> list | None:
@@ -9,6 +14,10 @@ def _run(pending: list[dict], changed: set[str]) -> list | None:
         patch(
             "web_scraper.scraper.SupabaseReader.get_pending_game_updates",
             return_value=pending,
+        ),
+        patch(
+            "web_scraper.scraper.SupabaseReader.get_pending_game_snapshot",
+            return_value=None,
         ),
         patch(
             "web_scraper.scraper.SupabaseReader.promote_pending_to_stable"
@@ -197,6 +206,10 @@ class TestStabilizePromoteCallShape:
                 return_value=pending,
             ),
             patch(
+                "web_scraper.scraper.SupabaseReader.get_pending_game_snapshot",
+                return_value=None,
+            ),
+            patch(
                 "web_scraper.scraper.SupabaseReader.promote_pending_to_stable"
             ) as mock_promote,
         ):
@@ -214,3 +227,163 @@ class TestStabilizePromoteCallShape:
 
         promoted = _run(pending=pending, changed=set())
         assert promoted == ["z9", "a1", "m5"]
+
+
+class TestFinalizeStabilizedGameUpdate:
+    def test_no_snapshot_returns_false_and_writes_nothing(self):
+        with (
+            patch(
+                "web_scraper.scraper.SupabaseReader.get_pending_game_snapshot",
+                return_value=None,
+            ),
+            patch(
+                "web_scraper.scraper.SupabaseReader.write_scraper_update"
+            ) as mock_write,
+            patch(
+                "web_scraper.scraper.SupabaseReader.delete_pending_game_snapshot"
+            ) as mock_delete,
+        ):
+            result = finalize_stabilized_game_update("game-001")
+
+        assert result is False
+        mock_write.assert_not_called()
+        mock_delete.assert_not_called()
+
+    def test_real_diff_writes_stable_row_and_deletes_snapshot(self):
+        snapshot = make_game(
+            ce_id="game-001",
+            objectives=[make_objective(ce_id="obj-a", point_value=10)],
+        )
+        current = make_game(
+            ce_id="game-001",
+            objectives=[make_objective(ce_id="obj-a", point_value=20)],
+        )
+
+        with (
+            patch(
+                "web_scraper.scraper.SupabaseReader.get_pending_game_snapshot",
+                return_value=snapshot,
+            ),
+            patch(
+                "web_scraper.scraper.SupabaseReader.get_game", return_value=current
+            ),
+            patch(
+                "web_scraper.scraper.SupabaseReader.write_scraper_update"
+            ) as mock_write,
+            patch(
+                "web_scraper.scraper.SupabaseReader.delete_pending_game_snapshot"
+            ) as mock_delete,
+        ):
+            result = finalize_stabilized_game_update("game-001")
+
+        assert result is True
+        mock_write.assert_called_once()
+        written_row = mock_write.call_args[0][0]
+        assert written_row["game_ce_id"] == "game-001"
+        assert written_row["status"] == "stable"
+        mock_delete.assert_called_once_with("game-001")
+
+    def test_net_zero_diff_writes_nothing_but_still_cleans_up(self):
+        """Points went up then back down across loops -- snapshot vs final
+        state shows no real change. Don't post a misleading empty message,
+        but still clear the snapshot so it doesn't leak forever."""
+        same_game = make_game(
+            ce_id="game-001",
+            objectives=[make_objective(ce_id="obj-a", point_value=10)],
+        )
+
+        with (
+            patch(
+                "web_scraper.scraper.SupabaseReader.get_pending_game_snapshot",
+                return_value=same_game,
+            ),
+            patch(
+                "web_scraper.scraper.SupabaseReader.get_game",
+                return_value=make_game(
+                    ce_id="game-001",
+                    objectives=[make_objective(ce_id="obj-a", point_value=10)],
+                ),
+            ),
+            patch(
+                "web_scraper.scraper.SupabaseReader.write_scraper_update"
+            ) as mock_write,
+            patch(
+                "web_scraper.scraper.SupabaseReader.delete_pending_game_snapshot"
+            ) as mock_delete,
+        ):
+            result = finalize_stabilized_game_update("game-001")
+
+        assert result is True
+        mock_write.assert_not_called()
+        mock_delete.assert_called_once_with("game-001")
+
+    def test_current_game_missing_still_cleans_up_snapshot(self):
+        """Game was removed entirely while its update was still pending."""
+        snapshot = make_game(ce_id="game-001")
+
+        with (
+            patch(
+                "web_scraper.scraper.SupabaseReader.get_pending_game_snapshot",
+                return_value=snapshot,
+            ),
+            patch("web_scraper.scraper.SupabaseReader.get_game", return_value=None),
+            patch(
+                "web_scraper.scraper.SupabaseReader.write_scraper_update"
+            ) as mock_write,
+            patch(
+                "web_scraper.scraper.SupabaseReader.delete_pending_game_snapshot"
+            ) as mock_delete,
+        ):
+            result = finalize_stabilized_game_update("game-001")
+
+        assert result is True
+        mock_write.assert_not_called()
+        mock_delete.assert_called_once_with("game-001")
+
+
+class TestStabilizeUsesFinalize:
+    def test_promoted_game_with_snapshot_deletes_stale_row_not_promotes_it(self):
+        pending = [{"id": "p1", "game_ce_id": "game-001"}]
+
+        with (
+            patch(
+                "web_scraper.scraper.SupabaseReader.get_pending_game_updates",
+                return_value=pending,
+            ),
+            patch(
+                "web_scraper.scraper.finalize_stabilized_game_update",
+                return_value=True,
+            ) as mock_finalize,
+            patch(
+                "web_scraper.scraper.SupabaseReader.promote_pending_to_stable"
+            ) as mock_promote,
+            patch(
+                "web_scraper.scraper.SupabaseReader.delete_stale_pending_update"
+            ) as mock_delete_stale,
+        ):
+            stabilize_pending_updates(set())
+
+        mock_finalize.assert_called_once_with("game-001")
+        mock_promote.assert_not_called()
+        mock_delete_stale.assert_called_once_with("p1")
+
+    def test_promoted_game_without_snapshot_falls_back_to_promote(self):
+        pending = [{"id": "p1", "game_ce_id": "game-001"}]
+
+        with (
+            patch(
+                "web_scraper.scraper.SupabaseReader.get_pending_game_updates",
+                return_value=pending,
+            ),
+            patch(
+                "web_scraper.scraper.finalize_stabilized_game_update",
+                return_value=False,
+            ) as mock_finalize,
+            patch(
+                "web_scraper.scraper.SupabaseReader.promote_pending_to_stable"
+            ) as mock_promote,
+        ):
+            stabilize_pending_updates(set())
+
+        mock_finalize.assert_called_once_with("game-001")
+        mock_promote.assert_called_once_with(["p1"])

--- a/tests/unit/test_stabilize_pending.py
+++ b/tests/unit/test_stabilize_pending.py
@@ -1,8 +1,7 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from tests.conftest import make_game, make_objective
 from web_scraper.scraper import (
-    UpdateMessageForScraperProcess,
     finalize_stabilized_game_update,
     stabilize_pending_updates,
 )
@@ -264,9 +263,7 @@ class TestFinalizeStabilizedGameUpdate:
                 "web_scraper.scraper.SupabaseReader.get_pending_game_snapshot",
                 return_value=snapshot,
             ),
-            patch(
-                "web_scraper.scraper.SupabaseReader.get_game", return_value=current
-            ),
+            patch("web_scraper.scraper.SupabaseReader.get_game", return_value=current),
             patch(
                 "web_scraper.scraper.SupabaseReader.write_scraper_update"
             ) as mock_write,

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -152,6 +152,8 @@ def finalize_stabilized_game_update(game_ce_id: str) -> bool:
     Note that this is run **after** the scraper loop has finished. So, the final
     version of the game exists in Supabase at this point.
     """
+
+    # this gate will trigger for new games
     snapshot = SupabaseReader.get_pending_game_snapshot(game_ce_id)
     if snapshot is None:
         return False

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -1374,7 +1374,9 @@ def create_update_updated_game(
     update.url = f"https://cedb.me/game/{game_new.ce_id}"
     update.location = "gameadditions"
     update.game_ce_id = game_new.ce_id
-    update.image = game_new.header if isinstance(game_new, CEAPIGame) else game_new._banner
+    update.image = (
+        game_new.header if isinstance(game_new, CEAPIGame) else game_new._banner
+    )
 
     # POINT/TIER CHANGE
     if game_old.get_total_points() == game_new.get_total_points():

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -126,18 +126,67 @@ def should_snapshot_pending_game(
     return game_ce_id not in existing_snapshot_ids
 
 
+def finalize_stabilized_game_update(game_ce_id: str) -> bool:
+    """Once a game stops changing, regenerate its diff message from the
+    pre-update snapshot vs. the now-final state, instead of relying on
+    whatever partial diff was generated on the last loop it changed.
+
+    Returns True if a snapshot existed and was handled (message written or
+    net-zero/missing-game cleanup), False if there was no snapshot at all
+    (caller should fall back to promoting the stale per-loop row as-is).
+    """
+    snapshot = SupabaseReader.get_pending_game_snapshot(game_ce_id)
+    if snapshot is None:
+        return False
+
+    current = SupabaseReader.get_game(game_ce_id)
+    if current is not None:
+        update, _ = create_update_updated_game(snapshot, current)
+        if update is not None:
+            row = {
+                "is_embed": update.is_embed,
+                "channel": update.location,
+                "text": update.text,
+                "title": update.title,
+                "description": update.description,
+                "image": update.image,
+                "url": update.url,
+                "color": update.color,
+                "game_ce_id": update.game_ce_id,
+                "status": "stable",
+            }
+            SupabaseReader.write_scraper_update(row)
+
+    SupabaseReader.delete_pending_game_snapshot(game_ce_id)
+    return True
+
+
 def stabilize_pending_updates(changed_game_ids: set[str]) -> None:
     pending = SupabaseReader.get_pending_game_updates()
     if not pending:
         return
 
-    to_promote = [
-        row["id"] for row in pending if row["game_ce_id"] not in changed_game_ids
-    ]
+    to_promote = [row for row in pending if row["game_ce_id"] not in changed_game_ids]
+    if not to_promote:
+        return
 
-    if to_promote:
-        SupabaseReader.promote_pending_to_stable(to_promote)
-        logger.info("Promoted %d pending updates to stable.", len(to_promote))
+    fallback_ids = []
+    for row in to_promote:
+        handled = finalize_stabilized_game_update(row["game_ce_id"])
+        if handled:
+            SupabaseReader.delete_stale_pending_update(row["id"])
+        else:
+            fallback_ids.append(row["id"])
+
+    if fallback_ids:
+        SupabaseReader.promote_pending_to_stable(fallback_ids)
+
+    logger.info(
+        "Stabilized %d pending game updates (%d regenerated, %d promoted as-is).",
+        len(to_promote),
+        len(to_promote) - len(fallback_ids),
+        len(fallback_ids),
+    )
 
 
 """ TOP LEVEL FUNCTION """

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -179,6 +179,15 @@ def finalize_stabilized_game_update(game_ce_id: str) -> bool:
 
 
 def stabilize_pending_updates(changed_game_ids: set[str]) -> None:
+    """
+    This function accepts `changed_game_ids`, which is a list of
+    game IDs that we can guarantee changed in between the previous two
+    scraper loops (rather than just blindly checking the `lastUpdated`
+    values).
+
+    If the game has not changed in between the last two loops, it will
+    not be in this array, and we can promote it.
+    """
     pending = SupabaseReader.get_pending_game_updates()
     if not pending:
         return

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -116,6 +116,16 @@ def compute_changed_game_ids(
     return {u.game_ce_id for u in updates if u.game_ce_id is not None} | removed_games
 
 
+def should_snapshot_pending_game(
+    game_ce_id: str,
+    update: UpdateMessageForScraperProcess | None,
+    existing_snapshot_ids: set[str],
+) -> bool:
+    if update is None:
+        return False
+    return game_ce_id not in existing_snapshot_ids
+
+
 def stabilize_pending_updates(changed_game_ids: set[str]) -> None:
     pending = SupabaseReader.get_pending_game_updates()
     if not pending:
@@ -460,6 +470,7 @@ async def update_games(
     else:
         _ids = [g.ce_id for g in games]
         games_old = SupabaseReader.get_games_bulk(_ids)
+        existing_snapshot_ids = SupabaseReader.get_pending_game_snapshot_ids()
 
         logger.info("Generating updates for games.")
         for i, game_new in enumerate(games):
@@ -470,6 +481,11 @@ async def update_games(
             _update, _or = update_one_game(game_old, game_new)
             if _update is not None:
                 updates.append(_update)
+                if game_old is not None and should_snapshot_pending_game(
+                    game_new.ce_id, _update, existing_snapshot_ids
+                ):
+                    SupabaseReader.upsert_pending_game_snapshot(game_old)
+                    existing_snapshot_ids.add(game_new.ce_id)
             if _or is not None:
                 objectives_removed.extend(_or)
 

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -1262,7 +1262,7 @@ def create_update_removed_game(game_old: CEGame) -> UpdateMessageForScraperProce
 
 
 def create_update_updated_game(
-    game_old: CEGame, game_new: CEAPIGame
+    game_old: CEGame, game_new: CEGame | CEAPIGame
 ) -> tuple[UpdateMessageForScraperProcess | None, list[str] | None]:
     """Creates the `UpdateMessageForScraperProcess` for an updated game.
 
@@ -1307,7 +1307,7 @@ def create_update_updated_game(
     update.url = f"https://cedb.me/game/{game_new.ce_id}"
     update.location = "gameadditions"
     update.game_ce_id = game_new.ce_id
-    update.image = game_new.header
+    update.image = game_new.header if isinstance(game_new, CEAPIGame) else game_new._banner
 
     # POINT/TIER CHANGE
     if game_old.get_total_points() == game_new.get_total_points():

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -1270,10 +1270,12 @@ def create_update_updated_game(
     ---
     game_old: `CEGame`
         The previous data for this game.
-    game_new: `CEAPIGame`
-        The new data for this game.
-        Comes with the added bonus of having
-        additional site information.
+    game_new: `CEGame` or `CEAPIGame`
+        The new data for this game. If a `CEAPIGame` is passed, it comes
+        with the added bonus of having additional site information, and
+        the update image uses its `.header`. If a plain `CEGame` is passed
+        instead (e.g. data read back from storage), the update image falls
+        back to its `._banner`.
 
     Returns
     -------

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -121,6 +121,19 @@ def should_snapshot_pending_game(
     update: UpdateMessageForScraperProcess | None,
     existing_snapshot_ids: set[str],
 ) -> bool:
+    """
+    This function checks that a game *should* be snapshotted out of
+    the regular `game` / `objective` / `objectiveRequirement` table
+    and into the `pending*` tables with the following logic:
+    - the game was actually updated since the
+      last scrape (non-empty update was generated)
+    - the game isn't a new game (checked outside of this function)
+    - the game isn't already in the `pending*` tables
+
+    Remember that the point of the `pending*` tables is to preserve
+    the **original** version of the game, to diff for the final update
+    that will be sent out.
+    """
     if update is None:
         return False
     return game_ce_id not in existing_snapshot_ids

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -140,13 +140,17 @@ def should_snapshot_pending_game(
 
 
 def finalize_stabilized_game_update(game_ce_id: str) -> bool:
-    """Once a game stops changing, regenerate its diff message from the
+    """
+    Once a game stops changing, regenerate its diff message from the
     pre-update snapshot vs. the now-final state, instead of relying on
     whatever partial diff was generated on the last loop it changed.
 
     Returns True if a snapshot existed and was handled (message written or
     net-zero/missing-game cleanup), False if there was no snapshot at all
     (caller should fall back to promoting the stale per-loop row as-is).
+
+    Note that this is run **after** the scraper loop has finished. So, the final
+    version of the game exists in Supabase at this point.
     """
     snapshot = SupabaseReader.get_pending_game_snapshot(game_ce_id)
     if snapshot is None:


### PR DESCRIPTION
## Summary

- Fixes PENDING.md Issue 2: when a tracked game updates more than once before it "stabilizes," the diff message posted to #gameadditions was previously built from only the *last* loop's change, silently losing the cumulative picture.
- Adds three new Supabase tables (`pendingGame`, `pendingObjective`, `pendingObjectiveRequirement`) that snapshot a game's pre-update state the first time it's detected as changed.
- At stabilization, regenerates the message by diffing the original snapshot against the game's final settled state, then cleans up the snapshot. Games with no snapshot (new games, or anything mid-cycle before this shipped) fall back to the exact prior behavior.
- `create_update_updated_game` now accepts a plain `CEGame` (not just `CEAPIGame`) for its `game_new` parameter, needed to diff against the snapshot-reconstructed state.

Implemented per `docs/superpowers/plans/2026-07-15-pending-game-snapshot-diff.md`, task-by-task with per-task review and a final whole-branch review.

**Requires manual setup before this is live:** the three new Supabase tables must be created via the SQL in the plan doc's "New Supabase Schema" section — no migration tooling exists in this repo.

## Test plan

- [x] 1600/1600 unit tests passing
- [x] `ruff check .` and `ruff format --check .` clean
- [x] Per-task review (spec compliance + code quality) for all 6 implementation tasks
- [x] Final whole-branch review: CRUD round-trip verified column-by-column, stabilization timing traced end-to-end (no stale-read window), backward-compat fallback verified for new games and pre-existing mid-cycle rows
- [x] Apply the SQL schema to the real Supabase project before merging to main / deploying