### PR TITLE
feat: add genre/info tags to game addition

### DIFF
--- a/Classes/CE_Game.py
+++ b/Classes/CE_Game.py
@@ -491,3 +491,86 @@ class CEAPIGame(CEGame):
     def header(self) -> str:
         "The header for this game."
         return self.full_data["header"]
+
+    @property
+    def genre_tags(self) -> list[dict]:
+        """
+        The genre tags.
+        If this game does not have `gameTags` as a key, this will return [].
+        """
+        if "gameTags" not in self.full_data:
+            return []
+        return self.__filter_tags(self.full_data["gameTags"], "genre")
+
+    @property
+    def informational_tags(self) -> list[dict]:
+        """
+        The informational tags.
+        If this game does not have `gameTags` as a key, this will return [].
+        """
+        if "gameTags" not in self.full_data:
+            return []
+        return self.__filter_tags(self.full_data["gameTags"], "informational")
+
+    @property
+    def informational_tags_exclusive(self) -> list[dict]:
+        """
+        The informational tags, exclusive of some 'excluded' tags.
+        If this game does not have `gameTags` as a key, this will return [].
+        """
+        tags = self.informational_tags
+
+        HAS_COMMUNITY_OBJECTIVES_ID = "0dd4a264-dfe6-4d85-8d24-fae23ca5250d"
+        HAS_SECONDARY_OBJECTIVES_ID = "23c84973-a07e-48db-96b1-97170cd0b759"
+        UNCLEARED_ID = "2b186758-b7c4-4888-abea-a94de550e311"
+        EXCLUDE = [
+            HAS_COMMUNITY_OBJECTIVES_ID,
+            HAS_SECONDARY_OBJECTIVES_ID,
+            UNCLEARED_ID,
+        ]
+
+        return [tag for tag in tags if tag["tagId"] not in EXCLUDE]
+
+    @property
+    def genre_tag_names(self) -> list[str]:
+        """
+        Returns the names of the genre tags associated with this game.
+        If this game has no genre tags, this will return [].
+        """
+        return [tag["tag"]["name"] for tag in self.genre_tags]
+
+    @property
+    def informational_tag_exclusive_names(self) -> list[str]:
+        """
+        Returns the names of the informational tags associated with this game.
+        If this game has no informational tags, this will return [].
+        """
+        return [tag["tag"]["name"] for tag in self.informational_tags_exclusive]
+
+    @staticmethod
+    def __filter_tags(tags: list[dict], tag_type: str):
+        """
+        Filters tags based on `type`.
+        This deduplicates logic from `self.genre_tags` and `self.informational_tags`, and any
+        future potential type addition.
+
+        Current layout of tags (13 July 2026):
+        ```
+        {
+            "gameId": "1e866995-6fec-452e-81ba-1e8f8594f4ea",
+            "tagId": "71d62012-2ca3-4514-8fa7-e9d0cc4128b5",
+            "createdAt": "2026-05-20T16:01:15.000Z",
+            "updatedAt": "2026-05-20T16:01:15.000Z",
+            "tag": {
+                "id": "71d62012-2ca3-4514-8fa7-e9d0cc4128b5",
+                "name": "Curated",
+                "icon": "",
+                "type": "informational",
+                "createdAt": "2026-04-01T16:09:16.000Z",
+                "updatedAt": "2026-04-01T16:09:16.000Z"
+            }
+        }
+        ```
+
+        """
+        return [tag for tag in tags if tag["tag"]["type"] == tag_type]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,12 @@ def make_user_game(
     )
 
 
+def make_game_tag(name: str, tag_type: str) -> dict:
+    """Builds a single `gameTags` entry as returned by the CE API."""
+    tag_id = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{tag_type}:{name}"))
+    return {"tagId": tag_id, "tag": {"name": name, "type": tag_type}}
+
+
 def make_api_game(
     ce_id: str = "game-001-0000-0000-000000000000",
     game_name: str = "Test Game",
@@ -104,6 +110,7 @@ def make_api_game(
     icon: str = "https://example.com/icon.jpg",
     is_finished: bool = True,
     information: str = "",
+    game_tags: list[dict] | None = None,
 ) -> CEAPIGame:
     full_data = {
         "header": header,
@@ -111,6 +118,8 @@ def make_api_game(
         "isFinished": is_finished,
         "information": information,
     }
+    if game_tags is not None:
+        full_data["gameTags"] = game_tags
     return CEAPIGame(
         ce_id=ce_id,
         game_name=game_name,

--- a/tests/unit/test_scraper_create_update_new_game.py
+++ b/tests/unit/test_scraper_create_update_new_game.py
@@ -1,5 +1,5 @@
 from Classes.CE_Objective import CEObjective
-from tests.conftest import make_api_game, make_objective
+from tests.conftest import make_api_game, make_game_tag, make_objective
 from web_scraper.scraper import create_update_new_game
 
 
@@ -142,3 +142,121 @@ class TestCreateUpdateNewGameObjectiveSummary:
         assert "Primary" in update.description
         assert "Secondary" in update.description
         assert "Community" in update.description
+
+
+def _genre_tag(name: str) -> dict:
+    return make_game_tag(name, "genre")
+
+
+def _info_tag(name: str) -> dict:
+    return make_game_tag(name, "informational")
+
+
+class TestCreateUpdateNewGameTags:
+    """
+    Tests for the genre/informational tag lines shown in the docstring:
+
+        - Genre tags: Tower Defense, Traditional Fighter (+3 more)
+        - Informational tags: Animal Protagonist, Curated (+18 more)
+    """
+
+    def test_no_genre_tags_line_when_no_genre_tags(self):
+        game = make_api_game(game_tags=[])
+        update = create_update_new_game(game)
+        assert "Genre tags" not in update.description
+
+    def test_no_informational_tags_line_when_no_informational_tags(self):
+        game = make_api_game(game_tags=[])
+        update = create_update_new_game(game)
+        assert "Informational tags" not in update.description
+
+    def test_genre_tags_line_shown_when_present(self):
+        game = make_api_game(game_tags=[_genre_tag("Tower Defense")])
+        update = create_update_new_game(game)
+        assert "Genre tags:" in update.description
+
+    def test_genre_tags_line_is_bullet(self):
+        game = make_api_game(game_tags=[_genre_tag("Tower Defense")])
+        update = create_update_new_game(game)
+        assert "\n- Genre tags:" in update.description
+
+    def test_genre_tag_names_appear_in_description(self):
+        game = make_api_game(
+            game_tags=[_genre_tag("Tower Defense"), _genre_tag("Traditional Fighter")]
+        )
+        update = create_update_new_game(game)
+        assert "Tower Defense" in update.description
+        assert "Traditional Fighter" in update.description
+
+    def test_genre_tags_no_more_suffix_when_two_or_fewer(self):
+        game = make_api_game(
+            game_tags=[_genre_tag("Tower Defense"), _genre_tag("Traditional Fighter")]
+        )
+        update = create_update_new_game(game)
+        assert "more" not in update.description
+
+    def test_genre_tags_more_suffix_matches_remaining_count(self):
+        game = make_api_game(
+            game_tags=[
+                _genre_tag("Tower Defense"),
+                _genre_tag("Traditional Fighter"),
+                _genre_tag("Roguelike"),
+                _genre_tag("Metroidvania"),
+                _genre_tag("Puzzle"),
+            ]
+        )
+        update = create_update_new_game(game)
+        assert "(+3 more)" in update.description
+
+    def test_informational_tags_line_shown_when_present(self):
+        game = make_api_game(game_tags=[_info_tag("Curated")])
+        update = create_update_new_game(game)
+        assert "Informational tags:" in update.description
+
+    def test_informational_tags_line_is_bullet(self):
+        game = make_api_game(game_tags=[_info_tag("Curated")])
+        update = create_update_new_game(game)
+        assert "\n- Informational tags:" in update.description
+
+    def test_informational_tag_names_appear_in_description(self):
+        game = make_api_game(
+            game_tags=[_info_tag("Animal Protagonist"), _info_tag("Curated")]
+        )
+        update = create_update_new_game(game)
+        assert "Animal Protagonist" in update.description
+        assert "Curated" in update.description
+
+    def test_informational_tags_no_more_suffix_when_two_or_fewer(self):
+        game = make_api_game(
+            game_tags=[_info_tag("Animal Protagonist"), _info_tag("Curated")]
+        )
+        update = create_update_new_game(game)
+        assert "more" not in update.description
+
+    def test_informational_tags_more_suffix_matches_remaining_count(self):
+        game = make_api_game(
+            game_tags=[_info_tag(f"Tag {i}") for i in range(20)],
+        )
+        update = create_update_new_game(game)
+        assert "(+18 more)" in update.description
+
+    def test_genre_and_informational_tags_appear_together(self):
+        game = make_api_game(
+            game_tags=[
+                _genre_tag("Tower Defense"),
+                _info_tag("Curated"),
+            ]
+        )
+        update = create_update_new_game(game)
+        assert "Genre tags:" in update.description
+        assert "Informational tags:" in update.description
+
+    def test_genre_tags_do_not_leak_into_informational_line(self):
+        game = make_api_game(game_tags=[_genre_tag("Tower Defense")])
+        update = create_update_new_game(game)
+        assert "Informational tags" not in update.description
+
+    def test_informational_tags_do_not_leak_into_genre_line(self):
+        game = make_api_game(game_tags=[_info_tag("Curated")])
+        update = create_update_new_game(game)
+        assert "Genre tags" not in update.description

--- a/web_scraper/scraper.py
+++ b/web_scraper/scraper.py
@@ -1181,6 +1181,8 @@ def create_update_new_game(game_new: CEAPIGame) -> UpdateMessageForScraperProces
     ---
     GAMENAME added to the site:
     - Tier4Emoji, ActionEmoji
+    - Genre tags: Tower Defense, Traditional Fighter (+3 more)
+    - Informational tags: Animal Protagonist, Curated (+18 more)
     - 3 Primary Objectives worth 25 points (+2 Uncleareds)
     - 5 Secondary Objectives worth 100 points (+1 Uncleared)
     - 1 Community Objective
@@ -1193,6 +1195,26 @@ def create_update_new_game(game_new: CEAPIGame) -> UpdateMessageForScraperProces
     update.url = f"https://cedb.me/game/{game_new.ce_id}"
     update.location = "gameadditions"
     update.game_ce_id = game_new.ce_id
+
+    # genre tags
+    NUM_GENRE_TAGS = 2
+    genre_tag_names = game_new.genre_tag_names
+    if len(genre_tag_names) != 0:
+        update.description += (
+            f"\n- Genre tags: {', '.join(genre_tag_names[:NUM_GENRE_TAGS])}"
+        )
+        if len(genre_tag_names) > NUM_GENRE_TAGS:
+            update.description += f" (+{len(genre_tag_names) - NUM_GENRE_TAGS} more)"
+
+    # informational tags
+    NUM_INFO_TAGS = 2
+    info_tag_names = game_new.informational_tag_exclusive_names
+    if len(info_tag_names) != 0:
+        update.description += (
+            f"\n- Informational tags: {', '.join(info_tag_names[:NUM_INFO_TAGS])}"
+        )
+        if len(info_tag_names) > NUM_INFO_TAGS:
+            update.description += f" (+{len(info_tag_names) - NUM_INFO_TAGS} more)"
 
     # primary
     num_pos = len(game_new.get_primary_objectives())


### PR DESCRIPTION
The first two (if applicable) tags should be shown on a game additions post as such:

GAMENAME added to the site:
- Tier4Emoji, ActionEmoji
- Genre tags: Tower Defense, Traditional Fighter (+3 more)
- Informational tags: Animal Protagonist, Curated (+18 more)
- 3 Primary Objectives worth 25 points (+2 Uncleareds)
- 5 Secondary Objectives worth 100 points (+1 Uncleared)
- 1 Community Objective